### PR TITLE
Add schema DSL method for cleaner schema definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Added: Added `schema` DSL method for cleaner schema definition. Supports `schema arguments: {...}, result: {...}` syntax. Fully backwards compatible with existing `ARGUMENTS_SCHEMA` and `RESULT_SCHEMA` constants.
 - Added: Added support from blocks on `rescue_from` to override default failure handler.
 
 ## [0.1.3] - 2025-10-10

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1,5 +1,5 @@
-1. Change rescue_from to allow multiple declarations, each with a specific mapping to the specified errors.
+1. Make sure Async Jobs don't retry when the job class cant be constantized.
 
-2. Make sure Async Jobs don't retry when the job class cant be constantized.
+2. Improve error handling with an error registry that can be referenced by codes as opposed to fully qualified class names.
 
-3. Improve error handling with an error registry that can be referenced by codes as opposed to fully qualified class names.
+3. Mock result objects from schema defaults

--- a/docs/core/architecture.md
+++ b/docs/core/architecture.md
@@ -30,12 +30,14 @@ The framework intercepts the `.call` class method to inject cross-cutting concer
 
 ### Schema Validation
 
-Define `ARGUMENTS_SCHEMA` or `RESULT_SCHEMA` constants, or create JSON files at `app/schemas/services/service_name/arguments.json`.
+Use the `schema` DSL method to define JSON Schema validation for arguments and results:
 
 ```ruby
 class Service < Servus::Base
-  ARGUMENTS_SCHEMA = { type: "object", required: ["user_id"] }.freeze
-  RESULT_SCHEMA = { type: "object", required: ["user"] }.freeze
+  schema(
+    arguments: { type: "object", required: ["user_id"] },
+    result: { type: "object", required: ["user"] }
+  )
 end
 ```
 

--- a/docs/core/overview.md
+++ b/docs/core/overview.md
@@ -51,16 +51,16 @@ Services can define JSON schemas for arguments and results. Validation happens a
 
 ```ruby
 class Service < Servus::Base
-  ARGUMENTS_SCHEMA = {
-    type: "object",
-    required: ["user_id", "amount"],
-    properties: {
-      user_id: { type: "integer" },
-      amount: { type: "number", minimum: 0.01 }
+  schema(
+    arguments: {
+      type: "object",
+      required: ["user_id", "amount"],
+      properties: {
+        user_id: { type: "integer" },
+        amount: { type: "number", minimum: 0.01 }
+      }
     }
-  }.freeze
-
-  # Or use external JSON file: app/schemas/services/service_name/arguments.json
+  )
 end
 ```
 

--- a/docs/features/schema_validation.md
+++ b/docs/features/schema_validation.md
@@ -4,7 +4,51 @@ Servus provides optional JSON Schema validation for service arguments and result
 
 ## How It Works
 
-Define schemas as constants or JSON files. The framework validates arguments before execution and results after execution. Invalid data raises `ValidationError`.
+Define schemas using the `schema` DSL method (recommended) or as constants. The framework validates arguments before execution and results after execution. Invalid data raises `ValidationError`.
+
+### Preferred: Schema DSL Method
+
+```ruby
+class ProcessPayment::Service < Servus::Base
+  schema(
+    arguments: {
+      type: "object",
+      required: ["user_id", "amount"],
+      properties: {
+        user_id: { type: "integer" },
+        amount: { type: "number", minimum: 0.01 }
+      }
+    },
+    result: {
+      type: "object",
+      required: ["transaction_id", "new_balance"],
+      properties: {
+        transaction_id: { type: "string" },
+        new_balance: { type: "number" }
+      }
+    }
+  )
+end
+```
+
+You can define just one schema if needed:
+
+```ruby
+class SendEmail::Service < Servus::Base
+  schema arguments: {
+    type: "object",
+    required: ["email", "subject"],
+    properties: {
+      email: { type: "string", format: "email" },
+      subject: { type: "string" }
+    }
+  }
+end
+```
+
+### Alternative: Inline Constants
+
+Constants are still supported for backwards compatibility:
 
 ```ruby
 class ProcessPayment::Service < Servus::Base
@@ -30,11 +74,18 @@ end
 
 ## File-Based Schemas
 
-For complex schemas, use JSON files instead of inline constants. Create files at:
+For complex schemas, use JSON files instead of inline definitions. Create files at:
 - `app/schemas/services/service_name/arguments.json`
 - `app/schemas/services/service_name/result.json`
 
-Servus checks for inline constants first, then JSON files. Schemas are cached after first load for performance.
+### Schema Lookup Precedence
+
+Servus checks for schemas in this order:
+1. **schema DSL method** (if defined)
+2. **Inline constants** (ARGUMENTS_SCHEMA, RESULT_SCHEMA)
+3. **JSON files** (in schema_root directory)
+
+Schemas are cached after first load for performance.
 
 ## Three Layers of Validation
 

--- a/docs/integration/configuration.md
+++ b/docs/integration/configuration.md
@@ -15,7 +15,7 @@ Servus.configure do |config|
 end
 ```
 
-This affects file-based schemas only - inline schema constants (ARGUMENTS_SCHEMA, RESULT_SCHEMA) are unaffected.
+This affects legacy file-based schemas only - schemas defined via the `schema` DSL method do not use files.
 
 ## Schema Cache
 

--- a/lib/servus/support/rescuer.rb
+++ b/lib/servus/support/rescuer.rb
@@ -117,7 +117,8 @@ module Servus
         #   end
         #
         # @param errors [Class<StandardError>] One or more exception classes to rescue from
-        # @param use [Class<Servus::Support::Errors::ServiceError>] Error class to use when wrapping exceptions (only used without block)
+        # @param use [Class<Servus::Support::Errors::ServiceError>] Error class to use when wrapping exceptions
+        #   (only used without block)
         # @yield [exception] Optional block for custom error handling
         # @yieldparam exception [StandardError] The caught exception
         # @yieldreturn [Servus::Support::Response] Must return success() or failure() response

--- a/spec/servus/support/validator_spec.rb
+++ b/spec/servus/support/validator_spec.rb
@@ -518,4 +518,342 @@ RSpec.describe Servus::Support::Validator do
       end
     end
   end
+
+  context 'with schema DSL method' do
+    before { described_class.clear_cache! }
+
+    after do
+      # Clean up class instance variables
+      if SchemaValidationTest::Service.instance_variable_defined?(:@arguments_schema)
+        SchemaValidationTest::Service.remove_instance_variable(:@arguments_schema)
+      end
+
+      if SchemaValidationTest::Service.instance_variable_defined?(:@result_schema)
+        SchemaValidationTest::Service.remove_instance_variable(:@result_schema)
+      end
+
+      # Clean up constants if they exist
+      if defined?(SchemaValidationTest::Service::ARGUMENTS_SCHEMA)
+        SchemaValidationTest::Service.send(:remove_const, :ARGUMENTS_SCHEMA)
+      end
+
+      if defined?(SchemaValidationTest::Service::RESULT_SCHEMA)
+        SchemaValidationTest::Service.send(:remove_const, :RESULT_SCHEMA)
+      end
+    end
+
+    describe 'schema class method' do
+      context 'when defining both arguments and result schemas' do
+        before do
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: ['name'],
+              properties: { name: { type: 'string' } }
+            },
+            result: {
+              type: 'object',
+              required: ['id'],
+              properties: { id: { type: 'integer' } }
+            }
+          )
+        end
+
+        it 'stores the arguments schema' do
+          expect(SchemaValidationTest::Service.arguments_schema).to be_a(Hash)
+          expect(SchemaValidationTest::Service.arguments_schema['type']).to eq('object')
+        end
+
+        it 'stores the result schema' do
+          expect(SchemaValidationTest::Service.result_schema).to be_a(Hash)
+          expect(SchemaValidationTest::Service.result_schema['type']).to eq('object')
+        end
+      end
+
+      context 'when defining only arguments schema' do
+        before do
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: ['name'],
+              properties: { name: { type: 'string' } }
+            }
+          )
+        end
+
+        it 'stores the arguments schema' do
+          expect(SchemaValidationTest::Service.arguments_schema).to be_a(Hash)
+        end
+
+        it 'does not set result schema' do
+          expect(SchemaValidationTest::Service.result_schema).to be_nil
+        end
+      end
+
+      context 'when defining only result schema' do
+        before do
+          SchemaValidationTest::Service.schema(
+            result: {
+              type: 'object',
+              required: ['id'],
+              properties: { id: { type: 'integer' } }
+            }
+          )
+        end
+
+        it 'stores the result schema' do
+          expect(SchemaValidationTest::Service.result_schema).to be_a(Hash)
+        end
+
+        it 'does not set arguments schema' do
+          expect(SchemaValidationTest::Service.arguments_schema).to be_nil
+        end
+      end
+    end
+
+    describe '.load_schema with DSL method' do
+      context 'when schema is defined via DSL' do
+        before do
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: %w[name age],
+              properties: { name: { type: 'string' }, age: { type: 'integer' } }
+            }
+          )
+        end
+
+        it 'loads and returns the schema from DSL' do
+          schema = described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          expect(schema).to be_a(Hash)
+          expect(schema['type']).to eq('object')
+          expect(schema['required']).to include('name', 'age')
+        end
+
+        it 'caches the schema' do
+          # Load once
+          described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          # Change the DSL schema
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: ['modified']
+            }
+          )
+
+          # Load again - should return cached version
+          schema = described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          expect(schema['required']).to include('name', 'age')
+          expect(schema['required']).not_to include('modified')
+        end
+      end
+
+      context 'when both DSL and constant exist' do
+        before do
+          # Define via DSL first
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: ['dsl_field'],
+              properties: { dsl_field: { type: 'string' } }
+            }
+          )
+
+          # Define constant
+          module SchemaValidationTest
+            class Service
+              ARGUMENTS_SCHEMA = {
+                type: 'object',
+                required: ['constant_field'],
+                properties: { constant_field: { type: 'string' } }
+              }.freeze
+            end
+          end
+        end
+
+        it 'uses DSL schema and ignores constant' do
+          schema = described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          expect(schema['required']).to include('dsl_field')
+          expect(schema['required']).not_to include('constant_field')
+        end
+      end
+
+      context 'when DSL schema is nil but constant exists' do
+        before do
+          # Define constant
+          module SchemaValidationTest
+            class Service
+              ARGUMENTS_SCHEMA = {
+                type: 'object',
+                required: ['constant_field'],
+                properties: { constant_field: { type: 'string' } }
+              }.freeze
+            end
+          end
+
+          # Set DSL schema to nil explicitly
+          SchemaValidationTest::Service.instance_variable_set(:@arguments_schema, nil)
+        end
+
+        it 'falls back to constant' do
+          schema = described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          expect(schema['required']).to include('constant_field')
+        end
+      end
+
+      context 'when no DSL, no constant, but file exists' do
+        let(:schema_dir) { Servus.config.schema_dir_for('schema_validation_test') }
+
+        before do
+          FileUtils.mkdir_p(schema_dir)
+          File.write(
+            "#{schema_dir}/arguments.json",
+            {
+              type: 'object',
+              required: ['file_field'],
+              properties: { file_field: { type: 'string' } }
+            }.to_json
+          )
+        end
+
+        after do
+          FileUtils.rm_rf(schema_dir)
+        end
+
+        it 'falls back to file-based schema' do
+          schema = described_class.load_schema(SchemaValidationTest::Service, 'arguments')
+
+          expect(schema['required']).to include('file_field')
+        end
+      end
+    end
+
+    describe '.validate_arguments with DSL schema' do
+      context 'when schema defined via DSL' do
+        before do
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: ['name'],
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'integer', minimum: 18 }
+              }
+            }
+          )
+        end
+
+        it 'returns true for valid arguments' do
+          expect(described_class.validate_arguments!(SchemaValidationTest::Service,
+                                                     { name: 'John', age: 25 })).to eq(true)
+        end
+
+        it 'raises ValidationError for missing required field' do
+          expect do
+            described_class.validate_arguments!(SchemaValidationTest::Service, { age: 25 })
+          end.to raise_error(Servus::Base::ValidationError, /required property of 'name'/)
+        end
+
+        it 'raises ValidationError for invalid field type' do
+          expect do
+            described_class.validate_arguments!(SchemaValidationTest::Service, { name: 'John', age: 'twenty' })
+          end.to raise_error(Servus::Base::ValidationError, /did not match the following type: integer/)
+        end
+
+        it 'raises ValidationError for out of range value' do
+          expect do
+            described_class.validate_arguments!(SchemaValidationTest::Service, { name: 'John', age: 17 })
+          end.to raise_error(Servus::Base::ValidationError, /did not have a minimum value of 18/)
+        end
+      end
+    end
+
+    describe '.validate_result with DSL schema' do
+      let(:success_result) { Servus::Support::Response.new(true, { id: 123 }, nil) }
+      let(:error_result) { Servus::Support::Response.new(false, nil, 'Error') }
+
+      context 'when schema defined via DSL' do
+        before do
+          SchemaValidationTest::Service.schema(
+            result: {
+              type: 'object',
+              required: %w[id status],
+              properties: {
+                id: { type: 'integer' },
+                status: { type: 'string' }
+              }
+            }
+          )
+        end
+
+        it 'returns error results unchanged without validation' do
+          expect(described_class.validate_result!(SchemaValidationTest::Service, error_result)).to eq(error_result)
+        end
+
+        it 'returns the success result unchanged if valid' do
+          valid_result = Servus::Support::Response.new(true, { id: 123, status: 'complete' }, nil)
+          expect(described_class.validate_result!(SchemaValidationTest::Service, valid_result)).to eq(valid_result)
+        end
+
+        it 'raises ValidationError if success result has invalid structure' do
+          expect do
+            described_class.validate_result!(SchemaValidationTest::Service, success_result)
+          end.to raise_error(Servus::Base::ValidationError, /did not contain a required property of 'status'/)
+        end
+
+        it 'raises ValidationError if success result has invalid types' do
+          invalid_result = Servus::Support::Response.new(true, { id: '123', status: 'complete' }, nil)
+          expect do
+            described_class.validate_result!(SchemaValidationTest::Service, invalid_result)
+          end.to raise_error(Servus::Base::ValidationError, /did not match the following type: integer/)
+        end
+      end
+    end
+
+    describe 'integration with service call' do
+      context 'when using DSL schema' do
+        before do
+          SchemaValidationTest::Service.schema(
+            arguments: {
+              type: 'object',
+              required: %w[name age],
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'integer', minimum: 18 }
+              }
+            },
+            result: {
+              type: 'object',
+              required: %w[id name age],
+              properties: {
+                id: { type: 'integer' },
+                name: { type: 'string' },
+                age: { type: 'integer' }
+              }
+            }
+          )
+        end
+
+        it 'validates arguments before call and result after call' do
+          result = SchemaValidationTest::Service.call(name: 'John', age: 25)
+
+          expect(result).to be_success
+          expect(result.data[:id]).to eq(123)
+          expect(result.data[:name]).to eq('John')
+          expect(result.data[:age]).to eq(25)
+        end
+
+        it 'raises ValidationError for invalid arguments' do
+          expect do
+            SchemaValidationTest::Service.call(name: 'John', age: 17)
+          end.to raise_error(Servus::Base::ValidationError, /did not have a minimum value of 18/)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
  ## Add `schema` DSL Method for Cleaner Schema Definition

  ### Summary

  Introduces a new `schema` DSL method for defining JSON Schema validation in a cleaner, more ergonomic way. This
  addresses developer experience issues with the current implementation where inline constants clutter service files
  and file-based schemas fail silently.

  ### Motivation

  Current schema definition approaches have several pain points:
  - **Inline constants clutter service files**: 20+ line `ARGUMENTS_SCHEMA` and `RESULT_SCHEMA` constants reduce
  readability
  - **Silent failures**: File-based schemas fail silently if files are missing, making it unclear if validation is
  active
  - **Manual loading**: Current workaround using `JSON.load_file` works but isn't elegant
  - **No discoverability**: No reliable way to know which services have schemas

  ### Changes

  #### New DSL Method

  Adds a clean, declarative syntax for schema definition:

  ```ruby
  # Before (old constant style)
  class ProcessPayment::Service < Servus::Base
    ARGUMENTS_SCHEMA = {
      type: "object",
      required: ["user_id", "amount"],
      properties: {
        user_id: { type: "integer" },
        amount: { type: "number", minimum: 0.01 }
      }
    }.freeze
  end

  # After (new DSL method)
  class ProcessPayment::Service < Servus::Base
    schema(
      arguments: {
        type: "object",
        required: ["user_id", "amount"],
        properties: {
          user_id: { type: "integer" },
          amount: { type: "number", minimum: 0.01 }
        }
      }
    )
  end
```

  Implementation Details

  Core Changes:
  - Added schema class method to Servus::Base accepting arguments: and result: keyword parameters
  - Added arguments_schema and result_schema accessor methods (private API)
  - Updated Servus::Support::Validator to check DSL schemas first, then constants, then files
  - Schemas automatically converted to HashWithIndifferentAccess for consistent key access

  Schema Resolution Precedence:
  1. Schemas defined via schema DSL method (new, recommended)
  2. Inline constants (ARGUMENTS_SCHEMA, RESULT_SCHEMA) - legacy support
  3. JSON files in schema_root directory - legacy support
  4. Returns nil if no schema found (validation remains opt-in)

  Backwards Compatibility:
  - ✅ Existing ARGUMENTS_SCHEMA and RESULT_SCHEMA constants continue to work
  - ✅ File-based schemas continue to work
  - ✅ Zero breaking changes
  - ✅ Gradual migration path

  Documentation Updates

  Updated all documentation to promote the new DSL method:
  - README.md: Updated schema validation section, marked legacy approaches
  - docs/features/schema_validation.md: Made DSL primary approach, updated precedence
  - docs/core/architecture.md: Updated example to use DSL
  - docs/core/overview.md: Updated example to use DSL
  - docs/integration/configuration.md: Clarified DSL schemas don't use files
  - CHANGELOG.md: Added entry for new feature

  Migration Path

  No immediate migration required. The new DSL is available immediately while maintaining full backwards
  compatibility. Teams can migrate at their own pace:

  1. Now: Start using schema DSL for new services
  2. Later: Gradually migrate existing services
  3. Future major version: Deprecate constants and file-based approaches

  Future Considerations

  This lays the groundwork for potential future enhancements:
  - Per-service validation modes (:strict, :warn, :optional)
  - Schema discovery and introspection tools
  - Built-in schema linting
  - Schema versioning support