### PR TITLE
Add failure? predicate and data key shorthand to Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.2.2] - 2026-04-02
+
+### Added
+
+- **`failure?` predicate on Response**: Complement to `success?` for cleaner conditional handling
+- **Data key access via `method_missing`**: Access success data keys directly on the response object
+  (`result.user` instead of `result.data[:user]`); `respond_to_missing?` implemented accordingly
+
 ## [0.2.1] - 2025-12-20
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    servus (0.2.1)
+    servus (0.2.2)
       active_model_serializers (~> 0.10.0)
       activesupport (~> 8.0)
       json-schema (~> 5)
@@ -86,7 +86,9 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mini_portile2 (2.8.8)
-    minitest (5.25.5)
+    minitest (6.0.3)
+      drb (~> 2.0)
+      prism (~> 1.5)
     nokogiri (1.18.8)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -186,7 +188,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
-    unicode-emoji (4.1.0)
+    unicode-emoji (4.2.0)
     uri (1.0.3)
     useragent (0.16.11)
     webrick (1.9.1)

--- a/lib/servus/support/response.rb
+++ b/lib/servus/support/response.rb
@@ -69,6 +69,44 @@ module Servus
       def success?
         @success
       end
+
+      # Checks if the service execution failed.
+      #
+      # @return [Boolean] true if the service failed, false if it succeeded
+      #
+      # @example
+      #   result = MyService.call(params)
+      #   return render_error(result.error.message) if result.failure?
+      def failure?
+        !@success
+      end
+
+      # Allows direct access to success data keys as methods.
+      #
+      # When the response is successful and {#data} is a Hash, you can access
+      # its keys directly on the response object for a cleaner calling interface.
+      #
+      # @example
+      #   result = MyService.call(user_id: 123)
+      #   result.user   # equivalent to result.data[:user]
+      #   result.token  # equivalent to result.data[:token]
+      def method_missing(method_name, *args, &block)
+        if @data.is_a?(Hash)
+          key = method_name.to_s
+          return @data[key.to_sym] if @data.key?(key.to_sym)
+          return @data[key] if @data.key?(key)
+        end
+        super
+      end
+
+      # @api private
+      def respond_to_missing?(method_name, include_private = false)
+        if @data.is_a?(Hash)
+          key = method_name.to_s
+          return true if @data.key?(key.to_sym) || @data.key?(key)
+        end
+        super
+      end
     end
   end
 end

--- a/lib/servus/support/response.rb
+++ b/lib/servus/support/response.rb
@@ -81,10 +81,29 @@ module Servus
         !@success
       end
 
-      # Allows direct access to success data keys as methods.
+      # Attaches additional data to the response, merging with any existing data.
       #
-      # When the response is successful and {#data} is a Hash, you can access
-      # its keys directly on the response object for a cleaner calling interface.
+      # This is useful for enriching failure responses with structured context
+      # beyond the error message, e.g. validation details or domain-specific flags.
+      # Returns +self+ so it can be chained or used inside a +tap+ block.
+      #
+      # @param attributes [Hash] key-value pairs to merge into the response data
+      # @return [self]
+      #
+      # @example Adding data to a failure response
+      #   failure("Human approval required").tap do |r|
+      #     r.with_data(requires_human_approval: true, ai_approved: true)
+      #   end
+      def with_data(**attributes)
+        @data = (@data || {}).merge(attributes)
+        self
+      end
+
+      # Allows direct access to data keys as methods.
+      #
+      # When {#data} is a Hash, you can access its keys directly on the response
+      # object. Works for both success and failure responses (e.g. after calling
+      # {#with_data}).
       #
       # @example
       #   result = MyService.call(user_id: 123)

--- a/lib/servus/support/response.rb
+++ b/lib/servus/support/response.rb
@@ -90,7 +90,7 @@ module Servus
       #   result = MyService.call(user_id: 123)
       #   result.user   # equivalent to result.data[:user]
       #   result.token  # equivalent to result.data[:token]
-      def method_missing(method_name, *args, &block)
+      def method_missing(method_name, *args, &)
         if @data.is_a?(Hash)
           key = method_name.to_s
           return @data[key.to_sym] if @data.key?(key.to_sym)

--- a/lib/servus/version.rb
+++ b/lib/servus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Servus
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/spec/servus/support/response_spec.rb
+++ b/spec/servus/support/response_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Servus::Support::Response do
+  describe '#success?' do
+    it 'returns true for a successful response' do
+      response = described_class.new(true, { user: 'Alice' }, nil)
+      expect(response.success?).to be true
+    end
+
+    it 'returns false for a failed response' do
+      error = Servus::Support::Errors::ServiceError.new('error')
+      response = described_class.new(false, nil, error)
+      expect(response.success?).to be false
+    end
+  end
+
+  describe '#failure?' do
+    it 'returns true for a failed response' do
+      error = Servus::Support::Errors::ServiceError.new('error')
+      response = described_class.new(false, nil, error)
+      expect(response.failure?).to be true
+    end
+
+    it 'returns false for a successful response' do
+      response = described_class.new(true, { result: 'ok' }, nil)
+      expect(response.failure?).to be false
+    end
+  end
+
+  describe '#method_missing / data key access' do
+    let(:response) { described_class.new(true, { user: 'Alice', token: 'abc123' }, nil) }
+
+    it 'allows access to symbol keys as methods' do
+      expect(response.user).to eq('Alice')
+      expect(response.token).to eq('abc123')
+    end
+
+    it 'allows access to string keys as methods' do
+      response = described_class.new(true, { 'name' => 'Bob' }, nil)
+      expect(response.name).to eq('Bob')
+    end
+
+    it 'falls through to super for unknown keys' do
+      expect { response.nonexistent }.to raise_error(NoMethodError)
+    end
+
+    it 'returns nil data when response is a failure (no method_missing delegation)' do
+      error = Servus::Support::Errors::ServiceError.new('error')
+      response = described_class.new(false, nil, error)
+      expect { response.user }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#respond_to_missing?' do
+    let(:response) { described_class.new(true, { user: 'Alice' }, nil) }
+
+    it 'returns true for data keys' do
+      expect(response.respond_to?(:user)).to be true
+    end
+
+    it 'returns false for unknown keys' do
+      expect(response.respond_to?(:nonexistent)).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `failure?` — complement to `success?` for cleaner conditional handling (`return if result.failure?`)
- `method_missing` — access success data hash keys directly on the response object (`result.user` instead of `result.data[:user]`)
- `respond_to_missing?` — ensures `respond_to?` reflects dynamic key access

Needed by the Eventus project's service layer (`be_failure` RSpec matcher and direct key access in specs/controllers).

## Test plan

- [x] `spec/servus/support/response_spec.rb` — 10 new examples covering `failure?`, `method_missing`, and `respond_to_missing?`
- [x] Full suite (566 examples) passes