### PR TITLE
Block external instantiation to enforce .call entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Added
+
+- **Service invocation lockdown**: `Servus::Base` now privatizes `.new` and any instance-level
+  `#call` so services must be invoked through the class-level `.call` pipeline. This guarantees
+  argument validation, logging, benchmarking, guards, result validation, and event emission are
+  never silently skipped by calling `MyService.new.call` directly. Enabled by default; opt out
+  with `Servus.configure { |c| c.lockdown_enabled = false }`. Implemented as
+  `Servus::Support::Lockdown` and gated by a new `Servus::Config#lockdown_enabled` flag.
+
 ## [0.3.0] - 2026-04-03
 
 ### Breaking Changes

--- a/lib/servus.rb
+++ b/lib/servus.rb
@@ -25,6 +25,7 @@ require_relative 'servus/support/response'
 require_relative 'servus/support/validator'
 require_relative 'servus/support/errors'
 require_relative 'servus/support/rescuer'
+require_relative 'servus/support/lockdown'
 require_relative 'servus/support/message_resolver'
 
 # Events

--- a/lib/servus/base.rb
+++ b/lib/servus/base.rb
@@ -57,6 +57,50 @@ module Servus
     Response = Servus::Support::Response
     Validator = Servus::Support::Validator
 
+    # Extended into every descendant so that any instance-level `#call`
+    # definition becomes private automatically. Services must be invoked
+    # through the class method {Servus::Base.call}, which applies argument
+    # validation, logging, benchmarking, guard handling, result validation,
+    # and event emission. Calling the instance method directly would silently
+    # skip all of that.
+    module EnforcePrivateCall
+      def method_added(name)
+        super
+        return unless Servus::Base.lockdown_enabled?
+
+        private :call if name == :call && public_method_defined?(:call)
+      end
+    end
+
+    @lockdown_enabled = true
+
+    class << self
+      # Whether external instantiation and direct `#call` invocation are
+      # blocked. Enabled by default in production; the test suite disables
+      # this to let internal specs exercise instance-level behavior in
+      # isolation. Not part of the public API.
+      # @api private
+      def lockdown_enabled?
+        @lockdown_enabled
+      end
+
+      # @api private
+      def lockdown_enabled=(value)
+        @lockdown_enabled = value
+        value ? singleton_class.send(:private, :new) : singleton_class.send(:public, :new)
+      end
+
+      private :new
+    end
+
+    # Installs the auto-privatize hook on every subclass. External
+    # `SomeService.new(...)` is already blocked because `new` is inherited as
+    # private from {Servus::Base}.
+    def self.inherited(subclass)
+      super
+      subclass.extend(EnforcePrivateCall)
+    end
+
     # Creates a successful response with the provided data.
     #
     # Use this method to return successful results from your service's call method.
@@ -196,7 +240,7 @@ module Servus
 
         # Wrap execution in catch block to handle guard failures
         result = catch(:guard_failure) do
-          benchmark(**args) { instance.call }
+          benchmark(**args) { instance.send(:call) }
         end
 
         # If result is a GuardError, a guard failed - wrap in failure Response

--- a/lib/servus/base.rb
+++ b/lib/servus/base.rb
@@ -48,6 +48,7 @@ module Servus
   class Base
     include Servus::Support::Errors
     include Servus::Support::Rescuer
+    include Servus::Support::Lockdown
     include Servus::Events::Emitter
     include Servus::Guards
 
@@ -56,50 +57,6 @@ module Servus
     Emitter = Servus::Events::Emitter
     Response = Servus::Support::Response
     Validator = Servus::Support::Validator
-
-    # Extended into every descendant so that any instance-level `#call`
-    # definition becomes private automatically. Services must be invoked
-    # through the class method {Servus::Base.call}, which applies argument
-    # validation, logging, benchmarking, guard handling, result validation,
-    # and event emission. Calling the instance method directly would silently
-    # skip all of that.
-    module EnforcePrivateCall
-      def method_added(name)
-        super
-        return unless Servus::Base.lockdown_enabled?
-
-        private :call if name == :call && public_method_defined?(:call)
-      end
-    end
-
-    @lockdown_enabled = true
-
-    class << self
-      # Whether external instantiation and direct `#call` invocation are
-      # blocked. Enabled by default in production; the test suite disables
-      # this to let internal specs exercise instance-level behavior in
-      # isolation. Not part of the public API.
-      # @api private
-      def lockdown_enabled?
-        @lockdown_enabled
-      end
-
-      # @api private
-      def lockdown_enabled=(value)
-        @lockdown_enabled = value
-        value ? singleton_class.send(:private, :new) : singleton_class.send(:public, :new)
-      end
-
-      private :new
-    end
-
-    # Installs the auto-privatize hook on every subclass. External
-    # `SomeService.new(...)` is already blocked because `new` is inherited as
-    # private from {Servus::Base}.
-    def self.inherited(subclass)
-      super
-      subclass.extend(EnforcePrivateCall)
-    end
 
     # Creates a successful response with the provided data.
     #

--- a/lib/servus/config.rb
+++ b/lib/servus/config.rb
@@ -56,6 +56,32 @@ module Servus
     # @return [Boolean] true to include default guards, false to exclude them
     attr_accessor :include_default_guards
 
+    # Whether external instantiation of services is blocked and instance
+    # `#call` methods are automatically privatized.
+    #
+    # When enabled (default), callers must invoke services via the class
+    # method {Servus::Base.call}, which runs argument validation, logging,
+    # benchmarking, guards, result validation, and event emission. Calling
+    # `MyService.new` or `instance.call` directly raises `NoMethodError`.
+    #
+    # Disable this if you have existing code that instantiates services
+    # directly or otherwise prefer to opt out of the enforcement.
+    #
+    # @return [Boolean] true to enforce lockdown (default), false to allow
+    #   direct instantiation and public instance `#call`
+    # @see Servus::Support::Lockdown
+    attr_reader :lockdown_enabled
+
+    # Sets whether lockdown is enforced, immediately re-applying the
+    # resulting `.new` visibility to {Servus::Base}.
+    #
+    # @param value [Boolean] the new lockdown setting
+    # @return [Boolean] the new value
+    def lockdown_enabled=(value)
+      @lockdown_enabled = value
+      Servus::Base.apply_lockdown!
+    end
+
     # Initializes a new configuration with default values.
     #
     # @api private
@@ -67,6 +93,7 @@ module Servus
 
       @strict_event_validation = true
       @include_default_guards  = true
+      @lockdown_enabled        = true
     end
 
     # Returns the full path to a service's schema file.

--- a/lib/servus/support/lockdown.rb
+++ b/lib/servus/support/lockdown.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Servus
+  module Support
+    # Enforces that services are invoked through {Servus::Base.call} rather
+    # than by instantiating a service and calling its instance `#call`
+    # directly. The class-level `.call` runs argument validation, logging,
+    # benchmarking, guard handling, result validation, and event emission;
+    # calling the instance method directly would silently skip all of that.
+    #
+    # When included in {Servus::Base}, this module:
+    # - Privatizes `.new` on the base class (and, by inheritance, on every
+    #   descendant) so `MyService.new` from outside the class raises
+    #   `NoMethodError`.
+    # - Installs a `method_added` hook on every descendant that privatizes
+    #   any instance-level `#call` at definition time.
+    #
+    # Controlled by {Servus::Config#lockdown_enabled} (default `true`). Set
+    # it to `false` to allow direct instantiation and public instance
+    # `#call` — useful if you have existing code that relies on those entry
+    # points, or if you prefer to opt out of this enforcement entirely.
+    #
+    # @example Opting out
+    #   Servus.configure do |config|
+    #     config.lockdown_enabled = false
+    #   end
+    #
+    # @see Servus::Config#lockdown_enabled
+    module Lockdown
+      # Wires the lockdown hooks into the including class.
+      #
+      # Extends the base with {ClassMethods} (for {ClassMethods#apply_lockdown!}),
+      # prepends {Inherited} so subclasses receive the `method_added` hook,
+      # and applies the current config value to `.new`'s visibility.
+      #
+      # @param base [Class] the class including this module (expected to be {Servus::Base})
+      # @return [void]
+      # @api private
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.singleton_class.prepend(Inherited)
+        base.apply_lockdown!
+      end
+
+      # Prepended onto the base class's singleton so that every subclass of
+      # {Servus::Base} is automatically extended with {PrivateCall} at
+      # class-definition time.
+      #
+      # @api private
+      module Inherited
+        # Ensures each subclass has the `method_added` hook installed.
+        #
+        # @param subclass [Class] the newly defined subclass
+        # @return [void]
+        def inherited(subclass)
+          super
+          subclass.extend(PrivateCall)
+        end
+      end
+
+      # Extended onto every {Servus::Base} subclass. Privatizes any
+      # instance-level `#call` as soon as it is defined, provided lockdown
+      # is enabled in config at definition time.
+      #
+      # @api private
+      module PrivateCall
+        # @param name [Symbol] the name of the newly added method
+        # @return [void]
+        def method_added(name)
+          super
+          return unless Servus.config.lockdown_enabled
+
+          private :call if name == :call && public_method_defined?(:call)
+        end
+      end
+
+      # Class-level helpers installed on {Servus::Base}.
+      module ClassMethods
+        # Applies {Servus::Config#lockdown_enabled} to `.new`'s visibility.
+        # Called on include and re-called whenever the config flag changes.
+        #
+        # @return [void]
+        # @api private
+        def apply_lockdown!
+          if Servus.config.lockdown_enabled
+            singleton_class.send(:private, :new)
+          else
+            singleton_class.send(:public, :new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/servus/base_lockdown_spec.rb
+++ b/spec/servus/base_lockdown_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Verifies that callers cannot bypass {Servus::Base.call} by instantiating a
+# service and invoking its `#call` directly. Doing so would skip argument
+# validation, logging, benchmarking, guard handling, result validation, and
+# event emission. The spec_helper re-publicizes `.new` for the rest of the
+# suite, so we re-privatize inside this example group to exercise the
+# production-facing behavior.
+RSpec.describe 'Servus::Base external instantiation lockdown' do
+  around do |example|
+    Servus::Base.lockdown_enabled = true
+    example.run
+  ensure
+    Servus::Base.lockdown_enabled = false
+  end
+
+  # Named constant so the validator can resolve a schema path (anonymous
+  # classes have nil #name). Defined lazily inside the around block so
+  # EnforcePrivateCall privatizes the instance `#call` at definition time.
+  let(:service_class) do
+    stub_const('LockdownTestService', Class.new(Servus::Base) do
+      def initialize(**); end
+
+      def call
+        success(nil)
+      end
+    end)
+  end
+
+  it 'raises when calling .new directly on a service subclass' do
+    expect { service_class.new }.to raise_error(NoMethodError, /private method/)
+  end
+
+  it 'raises when calling the instance #call after obtaining an instance' do
+    instance = service_class.send(:new)
+    expect { instance.call }.to raise_error(NoMethodError, /private method/)
+  end
+
+  it 'still allows invocation through the class method .call' do
+    result = service_class.call
+    expect(result).to be_success
+  end
+end

--- a/spec/servus/config_spec.rb
+++ b/spec/servus/config_spec.rb
@@ -46,4 +46,25 @@ RSpec.describe Servus::Config do
 
     after { Servus.config.include_default_guards = default_value }
   end
+
+  describe '#lockdown_enabled' do
+    # spec_helper disables lockdown so internal specs can instantiate
+    # anonymous Servus::Base subclasses directly. Restore that after each
+    # example so this suite doesn't leak state into other specs.
+    after { Servus.config.lockdown_enabled = false }
+
+    it 'toggles the public/private visibility of Servus::Base.new' do
+      Servus.config.lockdown_enabled = true
+      expect(Servus::Base.singleton_class.private_method_defined?(:new)).to be true
+
+      Servus.config.lockdown_enabled = false
+      expect(Servus::Base.singleton_class.public_method_defined?(:new)).to be true
+    end
+
+    it 'can be re-enabled after being disabled' do
+      Servus.config.lockdown_enabled = false
+      Servus.config.lockdown_enabled = true
+      expect(Servus.config.lockdown_enabled).to be true
+    end
+  end
 end

--- a/spec/servus/support/lockdown_spec.rb
+++ b/spec/servus/support/lockdown_spec.rb
@@ -5,20 +5,20 @@ require 'spec_helper'
 # Verifies that callers cannot bypass {Servus::Base.call} by instantiating a
 # service and invoking its `#call` directly. Doing so would skip argument
 # validation, logging, benchmarking, guard handling, result validation, and
-# event emission. The spec_helper re-publicizes `.new` for the rest of the
-# suite, so we re-privatize inside this example group to exercise the
+# event emission. The spec_helper disables lockdown for the rest of the
+# suite, so we re-enable it inside this example group to exercise the
 # production-facing behavior.
-RSpec.describe 'Servus::Base external instantiation lockdown' do
+RSpec.describe Servus::Support::Lockdown do
   around do |example|
-    Servus::Base.lockdown_enabled = true
+    Servus.config.lockdown_enabled = true
     example.run
   ensure
-    Servus::Base.lockdown_enabled = false
+    Servus.config.lockdown_enabled = false
   end
 
   # Named constant so the validator can resolve a schema path (anonymous
   # classes have nil #name). Defined lazily inside the around block so
-  # EnforcePrivateCall privatizes the instance `#call` at definition time.
+  # PrivateCall privatizes the instance `#call` at definition time.
   let(:service_class) do
     stub_const('LockdownTestService', Class.new(Servus::Base) do
       def initialize(**); end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ require 'spec_support/active_job_loader'
 # Production code blocks `.new` and privatizes `#call`; disable the lockdown
 # for the test suite. The lockdown itself is verified by
 # spec/servus/base_lockdown_spec.rb, which re-enables it within its own scope.
-Servus::Base.lockdown_enabled = false
+Servus.config.lockdown_enabled = false
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ require 'servus'
 require 'servus/testing'
 require 'spec_support/active_job_loader'
 
+# Internal tests sometimes instantiate anonymous Servus::Base subclasses to
+# exercise instance-level behavior (guards, lazy resolvers) in isolation.
+# Production code blocks `.new` and privatizes `#call`; disable the lockdown
+# for the test suite. The lockdown itself is verified by
+# spec/servus/base_lockdown_spec.rb, which re-enables it within its own scope.
+Servus::Base.lockdown_enabled = false
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
# Block external instantiation to enforce `.call` entry point

## Problem

`MyService.new(args).call` silently bypassed the framework lifecycle — argument validation, logging, benchmarking, guards, result validation, and event emission were all skipped. The service still "worked," but none of Servus's guarantees held.

## Fix

This change makes the bypass impossible at the language level:

- **`Servus::Base.new` is privatized.** Inherited by every subclass, so `MyService.new(...)` raises `NoMethodError` from outside the gem. The framework's own `Base.call` continues to work because implicit-self calls to private methods are allowed.
- **Subclass `#call` is auto-privatized.** A `method_added` hook installed via `EnforcePrivateCall` flips `#call` to private the moment a subclass defines it, so `instance.call` from outside also raises. `Base.call` invokes it via `instance.send(:call)`.

Together, both doors are locked: callers can't construct a service instance from outside, and even if they did, they couldn't invoke its `#call`. The single blessed entry point is `MyService.call(...)`.

## Test-mode escape hatch

The gem's own test suite has 30+ specs that legitimately use `service_class.new(...)` to exercise instance-level behavior in isolation (lazy resolvers, guards). Rather than rewriting those specs, this PR adds a `Servus::Base.lockdown_enabled` toggle (marked `@api private`) that disables both the `.new` block and the `method_added` privatization. The toggle is flipped off once in `spec/spec_helper.rb`.

The lockdown itself is verified by the new `spec/servus/base_lockdown_spec.rb`, which re-enables it within an `around` block to assert the production-facing contract: external `.new` raises, direct `#call` raises, and `.call` still works.

## Note on the `EnforcePrivateCall` module + `inherited` pattern

The hook could equivalently have been written as `def self.method_added` directly on `Base`. We chose the module + `extend(EnforcePrivateCall)` via `inherited` for two reasons:

1. **Scoping to subclasses.** The hook is conceptually about user-defined services, not about `Base` itself. Installing it via `inherited` makes that intent explicit and avoids running the hook for `Base`'s own method definitions.
2. **Future-proofing.** If `Base` ever defines its own instance `#call` (e.g., an abstract default that raises `NotImplementedError`), a hook on `Base` would auto-privatize it — potentially breaking the framework's own `instance.send(:call)` invocation. Scoping to subclasses avoids that footgun.

Neither is strictly necessary today, but together they make the design less fragile to changes in `Base`.

## Compatibility

For correctly-written client code (`MyService.call(...)`), this is a no-op. The only code that breaks is code that was already bypassing the framework — which is the whole point.

## Test plan

- [x] Full suite green (663 examples, 0 failures)
- [x] Rubocop clean on changed files
- [x] New `base_lockdown_spec.rb` verifies the lockdown contract end-to-end