### PR TITLE
Add config.tests_dir for generator spec paths

### DIFF
--- a/lib/generators/servus/event_handler/event_handler_generator.rb
+++ b/lib/generators/servus/event_handler/event_handler_generator.rb
@@ -44,7 +44,7 @@ module Servus
       # @return [String] spec file path
       # @api private
       def handler_spec_path
-        File.join('spec', Servus.config.events_dir, "#{file_name}_handler_spec.rb")
+        File.join(Servus.config.tests_dir, Servus.config.events_dir, "#{file_name}_handler_spec.rb")
       end
 
       # Returns the handler class name.

--- a/lib/generators/servus/guard/guard_generator.rb
+++ b/lib/generators/servus/guard/guard_generator.rb
@@ -44,7 +44,7 @@ module Servus
       # @return [String] spec file path
       # @api private
       def guard_spec_path
-        File.join('spec', Servus.config.guards_dir, "#{file_name}_guard_spec.rb")
+        File.join(Servus.config.tests_dir, Servus.config.guards_dir, "#{file_name}_guard_spec.rb")
       end
 
       # Returns the guard class name.

--- a/lib/generators/servus/service/service_generator.rb
+++ b/lib/generators/servus/service/service_generator.rb
@@ -57,7 +57,7 @@ module Servus
       # @return [String] spec file path
       # @api private
       def service_path_spec
-        "spec/services/#{file_path}/service_spec.rb"
+        "#{Servus.config.tests_dir}/services/#{file_path}/service_spec.rb"
       end
 
       # Returns the path for the result schema file.

--- a/lib/servus/config.rb
+++ b/lib/servus/config.rb
@@ -51,6 +51,15 @@ module Servus
     # @return [String] the guards directory path
     attr_accessor :guards_dir
 
+    # The directory where generated spec/test files are placed.
+    #
+    # Defaults to `"spec"`. Projects using Minitest or a custom test layout
+    # can override this (e.g., `"test"`) so generators write files into the
+    # correct location.
+    #
+    # @return [String] the tests directory path
+    attr_accessor :tests_dir
+
     # Whether to include the default built-in guards (EnsurePresent, EnsurePositive).
     #
     # @return [Boolean] true to include default guards, false to exclude them
@@ -64,6 +73,7 @@ module Servus
       @events_dir   = 'app/events'
       @schemas_dir  = 'app/schemas'
       @services_dir = 'app/services'
+      @tests_dir    = 'spec'
 
       @strict_event_validation = true
       @include_default_guards  = true

--- a/site/rails/configuration.md
+++ b/site/rails/configuration.md
@@ -15,6 +15,7 @@ Servus.configure do |config|
   config.schemas_dir  = "app/schemas"   # default: "app/schemas"
   config.events_dir   = "app/events"    # default: "app/events"
   config.guards_dir   = "app/guards"    # default: "app/guards"
+  config.tests_dir    = "spec"          # default: "spec"
 
   # ── Event Validation ────────────────────────────────────────────────
   # When true, Servus.validate_all_handlers! raises OrphanedHandlerError
@@ -32,4 +33,4 @@ Servus.configure do |config|
 end
 ```
 
-All six options are `attr_accessor` — read them with `Servus.config.schemas_dir` and write them in the `configure` block.
+All seven options are `attr_accessor` — read them with `Servus.config.schemas_dir` and write them in the `configure` block.

--- a/site/rails/generators.md
+++ b/site/rails/generators.md
@@ -70,7 +70,7 @@ The generated guard includes `http_status`, `error_code`, `message`, and a place
 
 ## Configuration
 
-All generators respect the directory settings in `Servus.configure`. If you've changed `schemas_dir`, `events_dir`, or `guards_dir`, the generated file paths follow those settings:
+All generators respect the directory settings in `Servus.configure`. If you've changed `schemas_dir`, `events_dir`, `guards_dir`, or `tests_dir`, the generated file paths follow those settings:
 
 ```ruby
 # config/initializers/servus.rb
@@ -79,6 +79,7 @@ Servus.configure do |config|
   config.events_dir   = "app/event_handlers" # default: "app/events"
   config.guards_dir   = "lib/guards"         # default: "app/guards"
   config.services_dir = "app/services"       # default: "app/services"
+  config.tests_dir    = "test"               # default: "spec"
 end
 ```
 

--- a/site/reference/generators.md
+++ b/site/reference/generators.md
@@ -292,6 +292,7 @@ Servus.configure do |config|
   config.schemas_dir  = "app/schemas"   # default: "app/schemas"
   config.events_dir   = "app/events"    # default: "app/events"
   config.guards_dir   = "app/guards"    # default: "app/guards"
+  config.tests_dir    = "spec"          # default: "spec"
 end
 ```
 

--- a/spec/generators/servus/event_handler_generator_spec.rb
+++ b/spec/generators/servus/event_handler_generator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'rails/generators'
+require 'generators/servus/event_handler/event_handler_generator'
+
+RSpec.describe Servus::Generators::EventHandlerGenerator do
+  let(:tmp_root) { Dir.mktmpdir('servus-generator-spec') }
+
+  around do |example|
+    original = Servus.config.tests_dir
+    example.run
+  ensure
+    Servus.config.tests_dir = original
+    FileUtils.rm_rf(tmp_root)
+  end
+
+  def invoke(name)
+    described_class.start([name], destination_root: tmp_root)
+  end
+
+  it 'places the spec under spec/ by default' do
+    invoke('gold_transferred')
+
+    expect(File).to exist(File.join(tmp_root, 'spec/app/events/gold_transferred_handler_spec.rb'))
+  end
+
+  it 'honours config.tests_dir when placing the spec' do
+    Servus.config.tests_dir = 'test'
+
+    invoke('gold_transferred')
+
+    expect(File).to exist(File.join(tmp_root, 'test/app/events/gold_transferred_handler_spec.rb'))
+    expect(File).not_to exist(File.join(tmp_root, 'spec/app/events/gold_transferred_handler_spec.rb'))
+  end
+end

--- a/spec/generators/servus/guard_generator_spec.rb
+++ b/spec/generators/servus/guard_generator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'rails/generators'
+require 'generators/servus/guard/guard_generator'
+
+RSpec.describe Servus::Generators::GuardGenerator do
+  let(:tmp_root) { Dir.mktmpdir('servus-generator-spec') }
+
+  around do |example|
+    original = Servus.config.tests_dir
+    example.run
+  ensure
+    Servus.config.tests_dir = original
+    FileUtils.rm_rf(tmp_root)
+  end
+
+  def invoke(name)
+    described_class.start([name], destination_root: tmp_root)
+  end
+
+  it 'places the spec under spec/ by default' do
+    invoke('eligible_transfer')
+
+    expect(File).to exist(File.join(tmp_root, 'spec/app/guards/eligible_transfer_guard_spec.rb'))
+  end
+
+  it 'honours config.tests_dir when placing the spec' do
+    Servus.config.tests_dir = 'test'
+
+    invoke('eligible_transfer')
+
+    expect(File).to exist(File.join(tmp_root, 'test/app/guards/eligible_transfer_guard_spec.rb'))
+    expect(File).not_to exist(File.join(tmp_root, 'spec/app/guards/eligible_transfer_guard_spec.rb'))
+  end
+end

--- a/spec/generators/servus/service_generator_spec.rb
+++ b/spec/generators/servus/service_generator_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'rails/generators'
+require 'generators/servus/service/service_generator'
+
+RSpec.describe Servus::Generators::ServiceGenerator do
+  let(:tmp_root) { Dir.mktmpdir('servus-generator-spec') }
+
+  around do |example|
+    original = Servus.config.tests_dir
+    example.run
+  ensure
+    Servus.config.tests_dir = original
+    FileUtils.rm_rf(tmp_root)
+  end
+
+  def invoke(name, *parameters)
+    described_class.start([name, *parameters], destination_root: tmp_root)
+  end
+
+  it 'places the spec under spec/ by default' do
+    invoke('treasury/transfer_gold', 'from_account')
+
+    expect(File).to exist(File.join(tmp_root, 'spec/services/treasury/transfer_gold/service_spec.rb'))
+  end
+
+  it 'honours config.tests_dir when placing the spec' do
+    Servus.config.tests_dir = 'test'
+
+    invoke('treasury/transfer_gold', 'from_account')
+
+    expect(File).to exist(File.join(tmp_root, 'test/services/treasury/transfer_gold/service_spec.rb'))
+    expect(File).not_to exist(File.join(tmp_root, 'spec/services/treasury/transfer_gold/service_spec.rb'))
+  end
+end

--- a/spec/servus/config_spec.rb
+++ b/spec/servus/config_spec.rb
@@ -32,6 +32,21 @@ RSpec.describe Servus::Config do
     after { Servus.config.guards_dir = default_dir }
   end
 
+  describe '#tests_dir' do
+    let(:default_dir) { 'spec' }
+
+    it 'defaults to spec' do
+      expect(Servus.config.tests_dir).to eq(default_dir)
+    end
+
+    it 'can be customized' do
+      Servus.config.tests_dir = 'test'
+      expect(Servus.config.tests_dir).to eq('test')
+    end
+
+    after { Servus.config.tests_dir = default_dir }
+  end
+
   describe '#include_default_guards' do
     let(:default_value) { true }
 


### PR DESCRIPTION
## Summary
- Adds `Servus.config.tests_dir` (default `"spec"`) so generators write spec files into the configured directory instead of a hardcoded `spec/`.
- Updates the service, guard, and event handler generators to respect it — projects using Minitest or a custom test layout can now point generators at `test/` without shuffling files.
- Documents the new option in `site/rails/configuration.md`, `site/rails/generators.md`, and `site/reference/generators.md`.

Closes #22.

## Test plan
- [x] `bundle exec rspec` — 668 examples, 0 failures
- [x] New regression specs under `spec/generators/servus/` cover default (`spec/`) and custom (`test/`) paths for all three generators; verified they fail against `main` and pass after the config change
- [x] New `tests_dir` coverage added to `spec/servus/config_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)