### PR TITLE
Add PersistedGuard and PositivityGuard built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Added
+
+- **`PersistedGuard`**: Built-in guard that ensures an ActiveModel-compatible record has been
+  persisted. Surfaces the record's full error messages as the failure message.
+  Method: `enforce_persisted!(record: user)` / `check_persisted?(record: user)`.
+- **`PositivityGuard`**: Built-in guard that ensures all provided numeric values are strictly
+  positive. Fails for zero, negative, and non-numeric values.
+  Method: `enforce_positivity!(amount: 10, fee: 1)` / `check_positivity?(amount: 10)`.
+
 ## [0.3.0] - 2026-04-03
 
 ### Breaking Changes

--- a/lib/servus/guards.rb
+++ b/lib/servus/guards.rb
@@ -39,6 +39,8 @@ module Servus
         require_relative 'guards/truthy_guard'
         require_relative 'guards/falsey_guard'
         require_relative 'guards/state_guard'
+        require_relative 'guards/persisted_guard'
+        require_relative 'guards/positivity_guard'
       end
     end
   end

--- a/lib/servus/guards/persisted_guard.rb
+++ b/lib/servus/guards/persisted_guard.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Servus
+  module Guards
+    # Guard that ensures an ActiveModel-compatible record has been persisted.
+    #
+    # Useful after `Model.create(...)` or `record.save` where validation
+    # failure leaves the record un-persisted with `errors` populated. Surfaces
+    # the record's full error messages as the failure message.
+    #
+    # @example Basic usage
+    #   class CreateUser < Servus::Base
+    #     def call
+    #       user = User.create(email: email, name: name)
+    #       enforce_persisted!(record: user)
+    #       success(user: user)
+    #     end
+    #   end
+    #
+    # @example Conditional check
+    #   if check_persisted?(record: user)
+    #     # user is persisted
+    #   end
+    class PersistedGuard < Servus::Guard
+      http_status 422
+      error_code 'record_not_persisted'
+
+      message '%<errors>s' do
+        message_data
+      end
+
+      # Tests whether the record has been persisted.
+      #
+      # @param record [#persisted?, #errors] an ActiveModel-compatible record
+      # @return [Boolean] true if the record is persisted
+      def test(record:)
+        record.persisted?
+      end
+
+      private
+
+      # Builds the interpolation data for the error message.
+      #
+      # @return [Hash] message interpolation data
+      def message_data
+        { errors: kwargs[:record].errors.full_messages.to_sentence }
+      end
+    end
+  end
+end

--- a/lib/servus/guards/positivity_guard.rb
+++ b/lib/servus/guards/positivity_guard.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Servus
+  module Guards
+    # Guard that ensures all provided numeric values are strictly positive.
+    #
+    # Fails for zero, negative, and non-numeric values. Mirrors the shape of
+    # {PresenceGuard} — accepts any number of keyword arguments and surfaces
+    # the first failing pair in the error message.
+    #
+    # @example Basic usage
+    #   class DebitAccount < Servus::Base
+    #     def call
+    #       enforce_positivity!(amount: amount, fee: fee)
+    #       # ...
+    #     end
+    #   end
+    #
+    # @example Single value
+    #   enforce_positivity!(amount: 10)
+    #
+    # @example Conditional check
+    #   if check_positivity?(amount: amount)
+    #     # amount is positive
+    #   end
+    class PositivityGuard < Servus::Guard
+      http_status 422
+      error_code 'must_be_positive'
+
+      message '%<key>s must be positive (got %<value>s)' do
+        message_data
+      end
+
+      # Tests whether all provided values are strictly positive numerics.
+      #
+      # @param values [Hash] keyword arguments to validate
+      # @return [Boolean] true if all values are strictly positive numerics
+      def test(**values)
+        values.all? { |_, value| positive?(value) }
+      end
+
+      private
+
+      # Builds the interpolation data for the error message.
+      #
+      # @return [Hash] message interpolation data
+      def message_data
+        failed_key, failed_value = find_failing_entry
+
+        {
+          key: failed_key,
+          value: failed_value.inspect
+        }
+      end
+
+      # Finds the first key-value pair that fails the positivity check.
+      #
+      # @return [Array<Symbol, Object>] the failing key and value
+      def find_failing_entry
+        kwargs.find { |_, value| !positive?(value) }
+      end
+
+      # Checks if a value is a strictly positive numeric.
+      #
+      # @param value [Object] the value to check
+      # @return [Boolean] true if the value is a numeric greater than zero
+      def positive?(value)
+        value.is_a?(Numeric) && value.positive?
+      end
+    end
+  end
+end

--- a/site/features/guards.md
+++ b/site/features/guards.md
@@ -149,7 +149,7 @@ This gives you a single, testable, and reusable guard that can be applied in any
 
 ## Built-in guards
 
-Servus ships with four basic guards — `PresenceGuard`, `TruthyGuard`, `FalseyGuard`, and `StateGuard`. They're useful as reference implementations for how to build guards, but the real value of the guard system comes from domain-specific guards like `EligibleTransferGuard` above.
+Servus ships with six basic guards — `PresenceGuard`, `TruthyGuard`, `FalseyGuard`, `StateGuard`, `PersistedGuard`, and `PositivityGuard`. They're useful as reference implementations for how to build guards, but the real value of the guard system comes from domain-specific guards like `EligibleTransferGuard` above.
 
 | Guard | Method | What it checks |
 | --- | --- | --- |
@@ -157,6 +157,8 @@ Servus ships with four basic guards — `PresenceGuard`, `TruthyGuard`, `FalseyG
 | `TruthyGuard` | `enforce_truthy!(on: user, check: :active?)` | Attribute is truthy |
 | `FalseyGuard` | `enforce_falsey!(on: user, check: :banned?)` | Attribute is falsey |
 | `StateGuard` | `enforce_state!(on: order, check: :status, is: :open)` | Attribute matches a value |
+| `PersistedGuard` | `enforce_persisted!(record: user)` | Record is persisted (surfaces `errors.full_messages`) |
+| `PositivityGuard` | `enforce_positivity!(amount: 10, fee: 1)` | Values are strictly positive numerics |
 
 ## Bang vs predicate
 

--- a/spec/servus/guards/persisted_spec.rb
+++ b/spec/servus/guards/persisted_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Servus::Guards::PersistedGuard do
+  let(:record_class) do
+    Struct.new(:persisted, :full_messages, keyword_init: true) do
+      def persisted?
+        persisted
+      end
+
+      def errors
+        self
+      end
+    end
+  end
+  let(:persisted_record) { record_class.new(persisted: true, full_messages: []) }
+  let(:unpersisted_record) do
+    record_class.new(persisted: false, full_messages: ['Email is invalid', 'Name can\'t be blank'])
+  end
+
+  describe '#test' do
+    it 'returns true when the record is persisted' do
+      guard = described_class.new(record: persisted_record)
+      expect(guard.test(record: persisted_record)).to be true
+    end
+
+    it 'returns false when the record is not persisted' do
+      guard = described_class.new(record: unpersisted_record)
+      expect(guard.test(record: unpersisted_record)).to be false
+    end
+  end
+
+  describe '#error' do
+    it 'returns GuardError with correct metadata' do
+      guard = described_class.new(record: unpersisted_record)
+      error = guard.error
+
+      expect(error).to be_a(Servus::Support::Errors::GuardError)
+      expect(error.code).to eq('record_not_persisted')
+      expect(error.http_status).to eq(422)
+    end
+
+    it 'surfaces the record\'s full error messages as the failure message' do
+      guard = described_class.new(record: unpersisted_record)
+      expect(guard.error.message).to eq('Email is invalid and Name can\'t be blank')
+    end
+  end
+
+  describe 'metadata' do
+    it 'has correct HTTP status' do
+      expect(described_class.http_status_code).to eq(422)
+    end
+
+    it 'has correct error code' do
+      expect(described_class.error_code_value).to eq('record_not_persisted')
+    end
+  end
+
+  describe 'method definition' do
+    it 'defines enforce_persisted! on Servus::Guards' do
+      expect(Servus::Guards.method_defined?(:enforce_persisted!)).to be true
+    end
+
+    it 'defines check_persisted? on Servus::Guards' do
+      expect(Servus::Guards.method_defined?(:check_persisted?)).to be true
+    end
+  end
+end

--- a/spec/servus/guards/positivity_spec.rb
+++ b/spec/servus/guards/positivity_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Servus::Guards::PositivityGuard do
+  describe '#test' do
+    context 'with strictly positive numerics' do
+      it 'returns true for positive integers' do
+        guard = described_class.new(amount: 10)
+        expect(guard.test(amount: 10)).to be true
+      end
+
+      it 'returns true for positive floats' do
+        guard = described_class.new(rate: 0.25)
+        expect(guard.test(rate: 0.25)).to be true
+      end
+
+      it 'returns true when all values are positive' do
+        guard = described_class.new(amount: 10, fee: 1)
+        expect(guard.test(amount: 10, fee: 1)).to be true
+      end
+    end
+
+    context 'with zero, negative, or non-numeric values' do
+      it 'returns false for zero' do
+        guard = described_class.new(amount: 0)
+        expect(guard.test(amount: 0)).to be false
+      end
+
+      it 'returns false for negative values' do
+        guard = described_class.new(amount: -5)
+        expect(guard.test(amount: -5)).to be false
+      end
+
+      it 'returns false for nil values' do
+        guard = described_class.new(amount: nil)
+        expect(guard.test(amount: nil)).to be false
+      end
+
+      it 'returns false for non-numeric values' do
+        guard = described_class.new(amount: '10')
+        expect(guard.test(amount: '10')).to be false
+      end
+
+      it 'returns false when any value is non-positive' do
+        guard = described_class.new(amount: 10, fee: 0)
+        expect(guard.test(amount: 10, fee: 0)).to be false
+      end
+    end
+  end
+
+  describe '#error' do
+    it 'returns GuardError with correct metadata' do
+      guard = described_class.new(amount: 0)
+      error = guard.error
+
+      expect(error).to be_a(Servus::Support::Errors::GuardError)
+      expect(error.code).to eq('must_be_positive')
+      expect(error.http_status).to eq(422)
+    end
+
+    it 'shows first failing key with zero value' do
+      guard = described_class.new(amount: 0)
+      expect(guard.error.message).to eq('amount must be positive (got 0)')
+    end
+
+    it 'shows first failing key with negative value' do
+      guard = described_class.new(fee: -1)
+      expect(guard.error.message).to eq('fee must be positive (got -1)')
+    end
+
+    it 'shows first failing key with nil value' do
+      guard = described_class.new(amount: nil)
+      expect(guard.error.message).to eq('amount must be positive (got nil)')
+    end
+
+    it 'shows first failing key when multiple fail' do
+      guard = described_class.new(amount: 10, fee: 0, bonus: -1)
+      expect(guard.error.message).to eq('fee must be positive (got 0)')
+    end
+  end
+
+  describe 'metadata' do
+    it 'has correct HTTP status' do
+      expect(described_class.http_status_code).to eq(422)
+    end
+
+    it 'has correct error code' do
+      expect(described_class.error_code_value).to eq('must_be_positive')
+    end
+  end
+
+  describe 'method definition' do
+    it 'defines enforce_positivity! on Servus::Guards' do
+      expect(Servus::Guards.method_defined?(:enforce_positivity!)).to be true
+    end
+
+    it 'defines check_positivity? on Servus::Guards' do
+      expect(Servus::Guards.method_defined?(:check_positivity?)).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `PersistedGuard` — ensures an ActiveModel-compatible record has been persisted. Surfaces `errors.full_messages.to_sentence` as the failure message. HTTP 422, error code `record_not_persisted`.
- Adds `PositivityGuard` — ensures all provided values are strictly positive numerics (rejects zero, negative, non-numeric). Mirrors the keyword-arg shape of `PresenceGuard` and surfaces the first failing key/value in the error message. HTTP 422, error code `must_be_positive`.
- Registers both in `lib/servus/guards.rb`, extends the built-ins table in `site/features/guards.md` (four → six), and adds `[Unreleased]` entries to `CHANGELOG.md`.

## Test plan
- [ ] `bundle exec rspec spec/servus/guards/persisted_spec.rb spec/servus/guards/positivity_spec.rb`
- [ ] Full spec suite passes with no regressions
- [ ] Confirm YARD docs render cleanly for both new guards
- [ ] Sanity-check the updated built-ins table on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)