### PR TITLE
Fix missing require for with_indifferent_access outside Rails

### DIFF
--- a/gem/lib/servus.rb
+++ b/gem/lib/servus.rb
@@ -4,6 +4,7 @@
 require 'json-schema'
 require 'active_support'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/core_ext/hash/indifferent_access'
 require 'active_model_serializers'
 
 # Servus namespace


### PR DESCRIPTION
Was playing around with Servus outside of Rails and came upon this issue.  
  
  - Fix missing require 'active_support/core_ext/hash/indifferent_access' in gem/lib/servus.rb
  - The gem uses with_indifferent_access in 6 places (base.rb, event.rb, validator.rb) but never explicitly requires the ActiveSupport extension that provides it
  - Works in Rails because Rails eagerly loads all of ActiveSupport; breaks in plain Ruby/Rack apps with NoMethodError: undefined method 'with_indifferent_access' for
   an instance of Hash

  Test plan

  - Verified the single-line change adds the require alongside the existing core_ext/class/attribute require
  - Run existing test suite to confirm no regressions
  - Test in a non-Rails Ruby app (e.g. plain Rack) to confirm the fix resolves the NoMethodError