### PR TITLE
feat(logging): FIZZY-3212: filter sensitive arguments from service-call logging (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,31 @@
-## [0.7.0] - 2026-08-14
+## [0.7.0] - 2026-08-15
 
 ### Added
 
-- **Credential filtering in service-call logging**: `Servus::Support::Logger.log_call` previously
-  logged service arguments verbatim (`args.inspect`), leaking credentials passed as service args
-  (session tokens, OmniAuth hashes, passwords) into application logs. Argument values are now
-  filtered through `ActiveSupport::ParameterFilter` before logging.
-
-  - New `Servus.config.log_filter_parameters` — accepts the same notations as
-    `ActiveSupport::ParameterFilter` (partial-match strings/symbols, regexps, procs). Defaults to a
-    credential-shaped deny-list (`passw`, `secret`, `token`, `_key`, `crypt`, `salt`, `auth`,
-    `certificate`, `otp`).
-  - In Rails applications the railtie merges the app's `config.filter_parameters` into the
-    default after boot, so Servus log filtering covers everything request-log filtering does —
-    no configuration needed, and an app with empty `filter_parameters` keeps the default
-    protection.
-
-  Filtered values appear as `[FILTERED]`:
+- **Opt-in credential filtering in service-call logging**: new `Servus.config.log_filter_parameters`
+  filters sensitive argument values out of `Servus::Support::Logger.log_call` lines via
+  `ActiveSupport::ParameterFilter`. Accepts the same notations as Rails' parameter filtering
+  (partial-match strings/symbols, regexps, procs). Filtered values appear as `[FILTERED]`:
 
   ```
   Calling Sessions::Resolve::Service with args: {token: "[FILTERED]"}
   ```
+
+  Defaults to `[]` — no filtering — so Servus imposes nothing and existing logging behavior is
+  unchanged. To enable it, set the keys you want masked in your app's initializer:
+
+  ```ruby
+  # config/initializers/servus.rb
+  Servus.configure do |config|
+    config.log_filter_parameters = [
+      :passw, :email, :secret, :token, :_key, :crypt, :salt,
+      :certificate, :otp, :ssn, :cvv, :cvc
+    ]
+  end
+  ```
+
+  Rails users can simply reuse their app's request-log filtering as the value:
+  `config.log_filter_parameters = Rails.application.config.filter_parameters`.
 
 ## [0.6.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [0.7.0] - 2026-08-14
+
+### Added
+
+- **Credential filtering in service-call logging**: `Servus::Support::Logger.log_call` previously
+  logged service arguments verbatim (`args.inspect`), leaking credentials passed as service args
+  (session tokens, OmniAuth hashes, passwords) into application logs. Argument values are now
+  filtered through `ActiveSupport::ParameterFilter` before logging.
+
+  - New `Servus.config.log_filter_parameters` — accepts the same notations as
+    `ActiveSupport::ParameterFilter` (partial-match strings/symbols, regexps, procs). Defaults to a
+    credential-shaped deny-list (`passw`, `secret`, `token`, `_key`, `crypt`, `salt`, `auth`,
+    `certificate`, `otp`).
+  - In Rails applications the railtie merges the app's `config.filter_parameters` into the
+    default after boot, so Servus log filtering covers everything request-log filtering does —
+    no configuration needed, and an app with empty `filter_parameters` keeps the default
+    protection.
+
+  Filtered values appear as `[FILTERED]`:
+
+  ```
+  Calling Sessions::Resolve::Service with args: {token: "[FILTERED]"}
+  ```
+
 ## [0.6.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
   Rails users can simply reuse their app's request-log filtering as the value:
   `config.log_filter_parameters = Rails.application.config.filter_parameters`.
 
+  The assigned list is frozen — reconfigure by assigning a new list rather than mutating in place.
+
 ## [0.6.0] - 2026-07-21
 
 ### Added

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    servus (0.6.0)
+    servus (0.7.0)
       activesupport (>= 8.0)
       json-schema (~> 5)
 

--- a/gem/lib/servus/config.rb
+++ b/gem/lib/servus/config.rb
@@ -124,7 +124,26 @@ module Servus
     #   config.log_filter_parameters = Rails.application.config.filter_parameters
     #
     # @return [Array] parameter filter patterns
-    attr_accessor :log_filter_parameters
+    attr_reader :log_filter_parameters
+
+    # Sets the log filter list, invalidating the memoized
+    # {#parameter_filter}. The list is frozen on assignment — reconfigure
+    # by assigning a new list, not by mutating in place.
+    #
+    # @param value [Array] parameter filter patterns
+    # @return [Array] the new value
+    def log_filter_parameters=(value)
+      @log_filter_parameters = Array(value).dup.freeze
+      @parameter_filter      = nil
+    end
+
+    # Parameter filter built from {#log_filter_parameters}, memoized until
+    # the list is reassigned.
+    #
+    # @return [ActiveSupport::ParameterFilter]
+    def parameter_filter
+      @parameter_filter ||= ActiveSupport::ParameterFilter.new(log_filter_parameters)
+    end
 
     # Sets whether lockdown is enforced, immediately re-applying the
     # resulting `.new` visibility to {Servus::Base}.
@@ -146,7 +165,7 @@ module Servus
       @require_service_arguments_schema = false
       @require_service_result_schema    = false
       @require_event_payload_schema     = false
-      @log_filter_parameters            = []
+      @log_filter_parameters            = [].freeze
     end
 
     def set_default_directories

--- a/gem/lib/servus/config.rb
+++ b/gem/lib/servus/config.rb
@@ -15,9 +15,6 @@ module Servus
   # @see Servus.config
   # @see Servus.configure
   class Config
-    # Credential-shaped keys filtered from argument logging by default.
-    DEFAULT_LOG_FILTER_PARAMETERS = %i[passw secret token _key crypt salt auth certificate otp].freeze
-
     # The directory where JSON schema files are located.
     #
     # Defaults to `Rails.root/app/schemas/services` in Rails applications.
@@ -116,12 +113,15 @@ module Servus
     attr_reader :lockdown_enabled
 
     # Keys whose values are filtered from Servus's service-call argument
-    # logging. Accepts the same notations as ActiveSupport::ParameterFilter
-    # (partial-match strings/symbols, regexps, procs).
+    # logging, shown as `[FILTERED]`. Accepts the same notations as
+    # ActiveSupport::ParameterFilter (partial-match strings/symbols,
+    # regexps, procs).
     #
-    # Defaults to a credential-shaped deny-list. In Rails applications the
-    # railtie replaces the default with the app's `filter_parameters` after
-    # boot, so filtering matches request-log filtering exactly.
+    # Defaults to `[]` — no filtering. Set the keys you want masked in your
+    # initializer; Rails users can simply reuse their app's request-log
+    # filtering as the value:
+    #
+    #   config.log_filter_parameters = Rails.application.config.filter_parameters
     #
     # @return [Array] parameter filter patterns
     attr_accessor :log_filter_parameters
@@ -146,7 +146,7 @@ module Servus
       @require_service_arguments_schema = false
       @require_service_result_schema    = false
       @require_event_payload_schema     = false
-      @log_filter_parameters            = DEFAULT_LOG_FILTER_PARAMETERS.dup
+      @log_filter_parameters            = []
     end
 
     def set_default_directories

--- a/gem/lib/servus/config.rb
+++ b/gem/lib/servus/config.rb
@@ -15,6 +15,9 @@ module Servus
   # @see Servus.config
   # @see Servus.configure
   class Config
+    # Credential-shaped keys filtered from argument logging by default.
+    DEFAULT_LOG_FILTER_PARAMETERS = %i[passw secret token _key crypt salt auth certificate otp].freeze
+
     # The directory where JSON schema files are located.
     #
     # Defaults to `Rails.root/app/schemas/services` in Rails applications.
@@ -112,6 +115,17 @@ module Servus
     # @see Servus::Support::Lockdown
     attr_reader :lockdown_enabled
 
+    # Keys whose values are filtered from Servus's service-call argument
+    # logging. Accepts the same notations as ActiveSupport::ParameterFilter
+    # (partial-match strings/symbols, regexps, procs).
+    #
+    # Defaults to a credential-shaped deny-list. In Rails applications the
+    # railtie replaces the default with the app's `filter_parameters` after
+    # boot, so filtering matches request-log filtering exactly.
+    #
+    # @return [Array] parameter filter patterns
+    attr_accessor :log_filter_parameters
+
     # Sets whether lockdown is enforced, immediately re-applying the
     # resulting `.new` visibility to {Servus::Base}.
     #
@@ -132,6 +146,7 @@ module Servus
       @require_service_arguments_schema = false
       @require_service_result_schema    = false
       @require_event_payload_schema     = false
+      @log_filter_parameters            = DEFAULT_LOG_FILTER_PARAMETERS.dup
     end
 
     def set_default_directories

--- a/gem/lib/servus/railtie.rb
+++ b/gem/lib/servus/railtie.rb
@@ -29,15 +29,6 @@ module Servus
       Servus::Events::Bus.enable_logging!
     end
 
-    # Runs after app initializers so additions made in
-    # config/initializers/filter_parameter_logging.rb are included. The app
-    # list is merged with (never replaces) the gem default, so an app with
-    # empty filter_parameters keeps credential filtering.
-    config.after_initialize do |app|
-      Servus.config.log_filter_parameters =
-        (app.config.filter_parameters + Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS).uniq
-    end
-
     # Load guards and event classes, clear caches on reload
     config.to_prepare do
       # Load custom guards from guards_dir

--- a/gem/lib/servus/railtie.rb
+++ b/gem/lib/servus/railtie.rb
@@ -29,6 +29,15 @@ module Servus
       Servus::Events::Bus.enable_logging!
     end
 
+    # Runs after app initializers so additions made in
+    # config/initializers/filter_parameter_logging.rb are included. The app
+    # list is merged with (never replaces) the gem default, so an app with
+    # empty filter_parameters keeps credential filtering.
+    config.after_initialize do |app|
+      Servus.config.log_filter_parameters =
+        (app.config.filter_parameters + Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS).uniq
+    end
+
     # Load guards and event classes, clear caches on reload
     config.to_prepare do
       # Load custom guards from guards_dir

--- a/gem/lib/servus/support/logger.rb
+++ b/gem/lib/servus/support/logger.rb
@@ -20,14 +20,17 @@ module Servus
 
       # Logs a call to a service.
       #
-      # Argument values are filtered through
-      # {Servus::Config#log_filter_parameters} so credentials (tokens,
-      # passwords, auth hashes) never reach the log line.
+      # When {Servus::Config#log_filter_parameters} is configured, matching
+      # argument values are replaced with `[FILTERED]` before logging. With
+      # the default empty list, arguments are logged verbatim.
       #
       # @param service_class [Class] The service class
       # @param args [Hash] The arguments passed to the service
       def self.log_call(service_class, args)
-        logger.info("Calling #{service_class.name} with args: #{parameter_filter.filter(args).inspect}")
+        filters = Servus.config.log_filter_parameters
+        rendered = Array(filters).empty? ? args : parameter_filter.filter(args)
+
+        logger.info("Calling #{service_class.name} with args: #{rendered.inspect}")
       end
 
       # Parameter filter built from the current configuration, rebuilt

--- a/gem/lib/servus/support/logger.rb
+++ b/gem/lib/servus/support/logger.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logger'
-require 'active_support/parameter_filter'
 
 module Servus
   module Support
@@ -27,26 +26,10 @@ module Servus
       # @param service_class [Class] The service class
       # @param args [Hash] The arguments passed to the service
       def self.log_call(service_class, args)
-        filters = Servus.config.log_filter_parameters
-        rendered = Array(filters).empty? ? args : parameter_filter.filter(args)
+        config = Servus.config
+        rendered = config.log_filter_parameters.empty? ? args : config.parameter_filter.filter(args)
 
         logger.info("Calling #{service_class.name} with args: #{rendered.inspect}")
-      end
-
-      # Parameter filter built from the current configuration, rebuilt
-      # whenever the configured filter list changes. The comparison snapshot
-      # is a copy, so in-place mutation of the list also triggers a rebuild.
-      #
-      # @return [ActiveSupport::ParameterFilter]
-      def self.parameter_filter
-        filters = Servus.config.log_filter_parameters
-
-        if @parameter_filter.nil? || @parameter_filter_source != filters
-          @parameter_filter_source = filters.dup
-          @parameter_filter = ActiveSupport::ParameterFilter.new(filters)
-        end
-
-        @parameter_filter
       end
 
       # Logs a result from a service

--- a/gem/lib/servus/support/logger.rb
+++ b/gem/lib/servus/support/logger.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'active_support/parameter_filter'
 
 module Servus
   module Support
@@ -17,12 +18,32 @@ module Servus
         end
       end
 
-      # Logs a call to a service
+      # Logs a call to a service.
+      #
+      # Argument values are filtered through
+      # {Servus::Config#log_filter_parameters} so credentials (tokens,
+      # passwords, auth hashes) never reach the log line.
       #
       # @param service_class [Class] The service class
       # @param args [Hash] The arguments passed to the service
       def self.log_call(service_class, args)
-        logger.info("Calling #{service_class.name} with args: #{args.inspect}")
+        logger.info("Calling #{service_class.name} with args: #{parameter_filter.filter(args).inspect}")
+      end
+
+      # Parameter filter built from the current configuration, rebuilt
+      # whenever the configured filter list changes. The comparison snapshot
+      # is a copy, so in-place mutation of the list also triggers a rebuild.
+      #
+      # @return [ActiveSupport::ParameterFilter]
+      def self.parameter_filter
+        filters = Servus.config.log_filter_parameters
+
+        if @parameter_filter.nil? || @parameter_filter_source != filters
+          @parameter_filter_source = filters.dup
+          @parameter_filter = ActiveSupport::ParameterFilter.new(filters)
+        end
+
+        @parameter_filter
       end
 
       # Logs a result from a service

--- a/gem/lib/servus/support/logger.rb
+++ b/gem/lib/servus/support/logger.rb
@@ -26,9 +26,7 @@ module Servus
       # @param service_class [Class] The service class
       # @param args [Hash] The arguments passed to the service
       def self.log_call(service_class, args)
-        config = Servus.config
-        rendered = config.log_filter_parameters.empty? ? args : config.parameter_filter.filter(args)
-
+        rendered = log_parameters(args)
         logger.info("Calling #{service_class.name} with args: #{rendered.inspect}")
       end
 
@@ -94,6 +92,18 @@ module Servus
       # @param exception [Exception] The uncaught exception
       def self.log_exception(service_class, exception)
         logger.error("#{service_class.name} uncaught exception: #{exception.class} - #{exception.message}")
+      end
+
+      # Filters parameters for logging based on the configured filter list.
+      #
+      # @param params [Hash] The parameters to filter
+      # @return [Hash] The filtered parameters
+      def self.log_parameters(params)
+        if Servus.config.log_filter_parameters.empty?
+          params
+        else
+          Servus.config.parameter_filter.filter(params)
+        end
       end
     end
   end

--- a/gem/lib/servus/version.rb
+++ b/gem/lib/servus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Servus
-  VERSION = '0.6.0'
+  VERSION = '0.7.0'
 end

--- a/gem/spec/servus/config_spec.rb
+++ b/gem/spec/servus/config_spec.rb
@@ -87,6 +87,34 @@ RSpec.describe Servus::Config do
     after { Servus.config.require_event_payload_schema = false }
   end
 
+  describe '#log_filter_parameters' do
+    after { Servus.config.log_filter_parameters = [] }
+
+    it 'defaults to an empty list' do
+      expect(Servus.config.log_filter_parameters).to eq([])
+    end
+
+    it 'can be customized' do
+      Servus.config.log_filter_parameters = %i[token]
+      expect(Servus.config.log_filter_parameters).to eq(%i[token])
+    end
+
+    it 'freezes the assigned list so it cannot be mutated in place' do
+      Servus.config.log_filter_parameters = %i[token]
+      expect { Servus.config.log_filter_parameters << :wand }.to raise_error(FrozenError)
+    end
+
+    it 'rebuilds the memoized parameter filter on reassignment' do
+      Servus.config.log_filter_parameters = %i[token]
+      stale_filter = Servus.config.parameter_filter
+
+      Servus.config.log_filter_parameters = %i[wand]
+
+      expect(Servus.config.parameter_filter).not_to be(stale_filter)
+      expect(Servus.config.parameter_filter.filter({ wand: 'elder' })).to eq({ wand: '[FILTERED]' })
+    end
+  end
+
   describe '#lockdown_enabled' do
     after { Servus.config.lockdown_enabled = false }
 

--- a/gem/spec/servus/support/logger_spec.rb
+++ b/gem/spec/servus/support/logger_spec.rb
@@ -8,48 +8,70 @@ RSpec.describe Servus::Support::Logger do
 
     before { allow(described_class.logger).to receive(:info) { |msg| messages << msg } }
 
-    it 'filters credential-shaped argument values' do
+    it 'logs arguments verbatim by default' do
       described_class.log_call(String, { token: 'ps_supersecret', name: 'ok' })
 
-      expect(messages.last).to include('[FILTERED]')
-      expect(messages.last).to include('"ok"')
-      expect(messages.last).not_to include('ps_supersecret')
+      expect(messages.last).to include('ps_supersecret')
+      expect(messages.last).not_to include('[FILTERED]')
     end
 
-    it 'filters partial-match keys like raw_token and password' do
-      described_class.log_call(String, { raw_token: 'abc', password: 'hunter2' })
+    context 'with log_filter_parameters configured' do
+      before { Servus.config.log_filter_parameters = %i[passw token auth] }
+      after { Servus.config.log_filter_parameters = [] }
 
-      expect(messages.last).not_to include('abc')
-      expect(messages.last).not_to include('hunter2')
+      it 'filters matching argument values' do
+        described_class.log_call(String, { token: 'ps_supersecret', name: 'ok' })
+
+        expect(messages.last).to include('[FILTERED]')
+        expect(messages.last).to include('"ok"')
+        expect(messages.last).not_to include('ps_supersecret')
+      end
+
+      it 'filters partial-match keys like raw_token and password' do
+        described_class.log_call(String, { raw_token: 'abc', password: 'hunter2' })
+
+        expect(messages.last).not_to include('abc')
+        expect(messages.last).not_to include('hunter2')
+      end
+
+      it 'filters auth-prefixed keys wholesale, including nested values' do
+        described_class.log_call(String, { auth_hash: { credentials: { token: 'ya29.secret' } } })
+
+        expect(messages.last).to include('[FILTERED]')
+        expect(messages.last).not_to include('ya29.secret')
+      end
+
+      it 'leaves non-matching keys visible' do
+        described_class.log_call(String, { wand: 'elder', token: 'hidden' })
+
+        expect(messages.last).to include('elder')
+        expect(messages.last).not_to include('hidden')
+      end
+
+      it 'picks up in-place mutations of the filter list' do
+        described_class.log_call(String, { wand: 'elder' })
+        expect(messages.last).to include('elder')
+
+        Servus.config.log_filter_parameters << :wand
+        described_class.log_call(String, { wand: 'elder' })
+
+        expect(messages.last).not_to include('elder')
+      end
     end
 
-    it 'filters auth-prefixed keys wholesale, including nested values' do
-      described_class.log_call(String, { auth_hash: { credentials: { token: 'ya29.secret' } } })
+    context 'with arbitrary custom keys configured' do
+      before { Servus.config.log_filter_parameters = %i[wand sigil] }
+      after { Servus.config.log_filter_parameters = [] }
 
-      expect(messages.last).to include('[FILTERED]')
-      expect(messages.last).not_to include('ya29.secret')
-    end
+      it 'masks their values as [FILTERED] while keeping the key names visible' do
+        described_class.log_call(String, { wand: 'elder', sigil: 'dark-mark', house: 'gryffindor' })
 
-    it 'picks up in-place mutations of the filter list' do
-      described_class.log_call(String, { wand: 'elder' })
-      expect(messages.last).to include('elder')
-
-      Servus.config.log_filter_parameters << :wand
-      described_class.log_call(String, { wand: 'elder' })
-
-      expect(messages.last).not_to include('elder')
-    ensure
-      Servus.config.log_filter_parameters = Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS.dup
-    end
-
-    it 'respects a customized filter list' do
-      Servus.config.log_filter_parameters = %i[wand]
-      described_class.log_call(String, { wand: 'elder', token: 'visible-now' })
-
-      expect(messages.last).not_to include('elder')
-      expect(messages.last).to include('visible-now')
-    ensure
-      Servus.config.log_filter_parameters = Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS.dup
+        expect(messages.last).to match(/wand.*?\[FILTERED\]/)
+        expect(messages.last).to match(/sigil.*?\[FILTERED\]/)
+        expect(messages.last).not_to include('elder')
+        expect(messages.last).not_to include('dark-mark')
+        expect(messages.last).to include('gryffindor')
+      end
     end
   end
 end

--- a/gem/spec/servus/support/logger_spec.rb
+++ b/gem/spec/servus/support/logger_spec.rb
@@ -48,11 +48,11 @@ RSpec.describe Servus::Support::Logger do
         expect(messages.last).not_to include('hidden')
       end
 
-      it 'picks up in-place mutations of the filter list' do
+      it 'applies a reassigned filter list on the next call' do
         described_class.log_call(String, { wand: 'elder' })
         expect(messages.last).to include('elder')
 
-        Servus.config.log_filter_parameters << :wand
+        Servus.config.log_filter_parameters = %i[wand]
         described_class.log_call(String, { wand: 'elder' })
 
         expect(messages.last).not_to include('elder')

--- a/gem/spec/servus/support/logger_spec.rb
+++ b/gem/spec/servus/support/logger_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Servus::Support::Logger do
+  describe '.log_call' do
+    let(:messages) { [] }
+
+    before { allow(described_class.logger).to receive(:info) { |msg| messages << msg } }
+
+    it 'filters credential-shaped argument values' do
+      described_class.log_call(String, { token: 'ps_supersecret', name: 'ok' })
+
+      expect(messages.last).to include('[FILTERED]')
+      expect(messages.last).to include('"ok"')
+      expect(messages.last).not_to include('ps_supersecret')
+    end
+
+    it 'filters partial-match keys like raw_token and password' do
+      described_class.log_call(String, { raw_token: 'abc', password: 'hunter2' })
+
+      expect(messages.last).not_to include('abc')
+      expect(messages.last).not_to include('hunter2')
+    end
+
+    it 'filters auth-prefixed keys wholesale, including nested values' do
+      described_class.log_call(String, { auth_hash: { credentials: { token: 'ya29.secret' } } })
+
+      expect(messages.last).to include('[FILTERED]')
+      expect(messages.last).not_to include('ya29.secret')
+    end
+
+    it 'picks up in-place mutations of the filter list' do
+      described_class.log_call(String, { wand: 'elder' })
+      expect(messages.last).to include('elder')
+
+      Servus.config.log_filter_parameters << :wand
+      described_class.log_call(String, { wand: 'elder' })
+
+      expect(messages.last).not_to include('elder')
+    ensure
+      Servus.config.log_filter_parameters = Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS.dup
+    end
+
+    it 'respects a customized filter list' do
+      Servus.config.log_filter_parameters = %i[wand]
+      described_class.log_call(String, { wand: 'elder', token: 'visible-now' })
+
+      expect(messages.last).not_to include('elder')
+      expect(messages.last).to include('visible-now')
+    ensure
+      Servus.config.log_filter_parameters = Servus::Config::DEFAULT_LOG_FILTER_PARAMETERS.dup
+    end
+  end
+end

--- a/site/features/logging.md
+++ b/site/features/logging.md
@@ -82,8 +82,33 @@ end
 
 ## Sensitive data
 
-Arguments are logged at `info` level. In production, either:
+Arguments are logged verbatim at `info` level. To keep credentials (tokens, passwords, auth hashes) out of your logs, configure `log_filter_parameters` — matching values are replaced with `[FILTERED]`:
+
+```ruby
+# config/initializers/servus.rb
+Servus.configure do |config|
+  config.log_filter_parameters = [
+    :passw, :email, :secret, :token, :_key, :crypt, :salt,
+    :certificate, :otp, :ssn, :cvv, :cvc
+  ]
+end
+```
+
+```
+INFO  Calling Sessions::Resolve::Service with args: {token: "[FILTERED]"}
+```
+
+The option accepts the same notations as `ActiveSupport::ParameterFilter`: partial-match strings/symbols, regexps, and procs. It defaults to `[]` — no filtering — so it's entirely opt-in, and it works in any Ruby app, not just Rails.
+
+Rails users can simply reuse their app's request-log filtering as the value, so Servus's argument logging matches it exactly (Rails' `filter_parameters` only applies to Servus logs if you assign it here — it isn't picked up automatically):
+
+```ruby
+config.log_filter_parameters = Rails.application.config.filter_parameters
+```
+
+Rails loads initializers alphabetically, so `config/initializers/filter_parameter_logging.rb` runs before `servus.rb` — any `filter_parameters += [...]` additions are included.
+
+Other options for production:
 
 1. Set the log level to `:warn` to suppress argument logging entirely
-2. Use Rails parameter filtering: `config.filter_parameters += [:password, :ssn]`
-3. Pass IDs instead of full objects: `Service.call(user_id: 1)` not `Service.call(user: user_object)`
+2. Pass IDs instead of full objects: `Service.call(user_id: 1)` not `Service.call(user: user_object)`

--- a/site/rails/configuration.md
+++ b/site/rails/configuration.md
@@ -35,6 +35,19 @@ Servus.configure do |config|
 
   config.include_default_guards = true  # default: true
 
+  # ── Log Filtering ───────────────────────────────────────────────────
+  # Filters sensitive argument values out of Servus's service-call log
+  # lines (shown as [FILTERED]). Accepts the same notations as
+  # ActiveSupport::ParameterFilter: partial-match strings/symbols,
+  # regexps, and procs. Defaults to [] (no filtering).
+  # Rails users can simply reuse their app's request-log filtering:
+  # config.log_filter_parameters = Rails.application.config.filter_parameters
+
+  config.log_filter_parameters = [                                    # default: []
+    :passw, :email, :secret, :token, :_key, :crypt, :salt,
+    :certificate, :otp, :ssn, :cvv, :cvc
+  ]
+
   # ── Schema Enforcement ─────────────────────────────────────────────
   # When true, Servus raises SchemaRequiredError if a service or Event
   # class is used without the corresponding schema defined. Useful for


### PR DESCRIPTION
## Problem

`Servus::Support::Logger.log_call` logs every service call's arguments verbatim (`args.inspect`). Any app passing credentials as service args leaks them into logs. Observed live in Machina Console's production CloudWatch: raw `ps_` session bearer tokens on every request (`Sessions::Resolve`) and full Google OAuth auth hashes (access + id tokens) from `Sessions::CreateFromOmniauth`.

Fizzy: https://fizzy.internal.zarhq.dev/0000001/cards/3212

## Change

- `Logger.log_call` masks argument values matching `Servus.config.log_filter_parameters` via `ActiveSupport::ParameterFilter` before logging → `{token: "[FILTERED]"}`.
- `log_filter_parameters` is a **pure, opt-in config option**: it defaults to `[]` (no filtering), and Servus never touches it after boot — whatever the app sets in `config/initializers/servus.rb` is authoritative. Accepts all `ParameterFilter` notations (partial-match strings/symbols, regexps, procs). With the default empty list, `log_call` short-circuits, so unconfigured behavior is byte-identical to 0.6.0.
- The recommended defaults live at the app level, not the gem level: the documented initializer (`site/rails/configuration.md`) sets the option to Rails' stock credential list (`passw email secret token _key crypt salt certificate otp ssn cvv cvc`), and `site/features/logging.md` explains the option. Rails users can simply reuse their app's request-log filtering: `config.log_filter_parameters = Rails.application.config.filter_parameters`.
- The `ActiveSupport::ParameterFilter` is memoized on `Config` and invalidated by the writer. The assigned list is dup'd and **frozen**, so in-place mutation (`<<`) raises `FrozenError` instead of silently drifting from the memoized filter — reconfiguring means assigning a new list. Runtime mutation of filter params is explicitly not a supported contract.
- Version 0.7.0 + CHANGELOG entry.

### Design revision

An earlier revision of this PR shipped a gem-level deny-list default and a railtie `config.after_initialize` hook that merged the app's `filter_parameters` into it. That hook ran after all app initializers, so it silently clobbered anything set in `config/initializers/servus.rb`, and the deny-list was impossible to opt out of (args named e.g. `author` or `token_count` would always log as `[FILTERED]`). Both are removed — the gem imposes nothing; the defaults are configuration, documented in the initializer example.

## Adversarial review

Codex challenge review ran against the original diff; both findings addressed:
1. **High** — railtie originally *replaced* the default with the app list (empty app list would disable filtering). Superseded: the railtie hook is now removed entirely.
2. **Medium** — memoization compared against the same array reference (in-place mutation never rebuilt). Superseded: the logger's change-polling cache is removed entirely; memoization lives on `Config` and the writer invalidates it, with the frozen list making in-place mutation an error.

## Testing

- `spec/servus/support/logger_spec.rb` (7 examples): verbatim logging by default; with a configured list — value filtering, partial-match keys (`raw_token`, `password`), wholesale nested filtering, non-matching keys stay visible, reassignment applied on the next call; arbitrary custom keys (`wand`, `sigil`) masked as `[FILTERED]` with key names kept visible.
- `spec/servus/config_spec.rb` (`#log_filter_parameters`, 4 examples): empty default, customization, frozen-list contract (`<<` raises `FrozenError`), memoized filter rebuilt on reassignment.
- Full suite: 789 examples, 0 failures; rubocop clean.

## Release

After merge: publish GitHub Release `v0.7.0` (triggers the RubyGems publish workflow). Machina Console then bumps `0.2.1 → 0.7.0` (FIZZY-3211), **adds `config.log_filter_parameters` to its `config/initializers/servus.rb`** (filtering is opt-in — without it, args log verbatim), and deletes its app-level override initializer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
