### PR TITLE
chore(ci): FIZZY-3583: deploy docs with GITHUB_TOKEN instead of a user PAT

### DIFF
--- a/.github/workflows/yard-docs.yml
+++ b/.github/workflows/yard-docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
@@ -26,5 +29,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GH_PAT }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site/.vitepress/dist


### PR DESCRIPTION
## What

`yard-docs.yml` deployed GitHub Pages using `secrets.GH_PAT` — a personal access token tied to an individual account. This swaps it for the built-in `GITHUB_TOKEN` and declares the `contents: write` permission the Pages push needs.

## Why

On 2026-08-27, org-level 2FA method enforcement (SMS disallowed) invalidated the personal access token behind zarpay/core's Fingerprint job and broke every core PR for ~2 hours. Any workflow secret tied to an individual account can repeat that. `GH_PAT` here is the same shape of hazard.

Same-repo Pages deploys don't need a PAT, so this one needs no GitHub App — just the built-in token.

## Why `GITHUB_TOKEN` is sufficient here

The usual reason a Pages/push step needs a PAT is that pushes made with `GITHUB_TOKEN` don't trigger workflow events. That doesn't bite here:

- Pages on this repo is `build_type: legacy` with source branch `gh-pages`. Branch-source Pages builds are run by the Pages service, not the Actions event system, so the loop-prevention rule doesn't apply.
- The repo is public, which is `peaceiris/actions-gh-pages`' explicitly supported case for `GITHUB_TOKEN` (it's their recommended default).
- `gh-pages` has no branch protection.
- The repo's default workflow permissions are already `write`. The explicit `permissions:` block isn't strictly required today — it's there so the workflow doesn't silently break if the org default ever flips to read-only, and so the requirement is stated where it's used.

## Verification

After merge, the next push to `main` should produce a green `Deploy docs` run and an updated https://zarpay.github.io/servus/.

## Follow-up (not in this PR)

The `GH_PAT` secret still exists on this repo and should be deleted once a docs deploy is confirmed green on the new token.

Fizzy: https://fizzy.internal.zarhq.dev/1/cards/3583