### PR TITLE
fix(deps): FIZZY-3597: add site/.npmrc so the npm Dependabot block runs

### DIFF
--- a/site/.npmrc
+++ b/site/.npmrc
@@ -1,0 +1,3 @@
+# Scope mapping only — tells Dependabot the org private-registry credential
+# applies solely to @zarpay/*; no @zarpay packages are installed here.
+@zarpay:registry=https://npm.pkg.github.com/


### PR DESCRIPTION
## Why

Follow-up to #57. That PR fixed the Dependabot config, and three of the four blocks now run clean — `bundler /gem` and `bundler /gem/spec/dummy` opened grouped PRs (#59, #58) and `github-actions` ran with nothing to do.

The npm `/site` block still fails, on both the version-update and the security-update job:

```
private_registry_config_not_found  {"source": "npm.pkg.github.com/"}
Private npm registries require either a .npmrc file in your repository,
or explicit `scope`/`replaces-base` configuration in dependabot.yml
```

The org injects `npm.pkg.github.com` into every npm block, so Dependabot aborts during file fetching unless the directory carries an `.npmrc` or the block declares a scope. This is not a regression from #57 — the block simply never ran to completion before, so the fault only became visible once the config parsed.

## What changed

One new file, `site/.npmrc`, matching `machina/docs/.npmrc`:

```
@zarpay:registry=https://npm.pkg.github.com/
```

Scope mapping only, no auth token. `/site` installs `vitepress` and `vue` and no `@zarpay` packages, so it never needs to authenticate against the private registry — this just tells Dependabot the org credential is scoped to `@zarpay/*` and is irrelevant here.

## Verification

- `npm ci` — clean
- `npm run build` — build completes, pages render

## Risks

Minimal. The file adds a scope mapping for a scope the site does not use, and carries no credential. Local and CI installs resolve from the public registry exactly as before, which the clean `npm ci` above confirms.

## What this does not do

It will **not** close the 4 remaining alerts (3× `vite`, 1× `esbuild`). Those are `development` scope and structurally blocked: `vitepress ^1.6.4` is the current release and hard-pins `vite: ^5.4.14`, with `esbuild` arriving transitively through vite 5. They cannot close without dropping or replacing vitepress.

This change only stops the npm block erroring on every run, so future `/site` updates are actually picked up.

Part of FIZZY-3597.