### PR TITLE
fix(deps): FIZZY-3597: stop version updates on the dummy app block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,14 @@ updates:
         patterns:
           - "*"
 
-  # The dummy Rails app that hosts the specs. Its lockfile is tracked
-  # deliberately (FIZZY-3597), so it needs its own block — otherwise security
-  # updates scan it while version updates never keep it current.
+  # The dummy Rails app that hosts the specs. Nothing runs it — not CI, the
+  # Rakefile, the gem's Gemfile, or the specs — so routine version drift here
+  # exercises nothing, and a bump to its Rails pin drags the published gemspec
+  # along with it. Limit 0 disables *version* updates; security updates are
+  # exempt from the limit, so advisories against this lockfile still get PRs.
   - package-ecosystem: bundler
     directory: /gem/spec/dummy
+    open-pull-requests-limit: 0
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Why

#58 proposed bumping the dummy app's Rails pin from `~> 8.0.4` to `~> 8.1.3`. It was closed, for three reasons:

- **It exercises nothing.** `gem/spec/dummy` is not referenced by CI, the Rakefile, the gem's Gemfile, or the specs — the 909 examples resolve entirely from `gem/Gemfile.lock`.
- **It reached into the published gem.** Bumping the dummy's Rails pin dragged `gem/servus.gemspec` along with it, widening `json-schema '~> 5'` to `'>= 5', '< 7'` — a change to what *consumers* resolve, proposed by a dummy-app dependency group.
- **It could not pass.** It edited the gemspec without updating `gem/Gemfile.lock`, whose PATH section still records `json-schema (~> 5)`. CI runs frozen, so all four jobs failed with `The gemspecs for path gems changed, but the lockfile can't be updated because frozen mode is set`. That lockfile belongs to the `/gem` block and Dependabot will not cross into it from this one.

Left alone, Dependabot re-proposes this every week.

## What changed

`open-pull-requests-limit: 0` on the `/gem/spec/dummy` block.

Per the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), this disables **version** updates for the block, while *"Security update pull requests are not subject to this limit and do not count toward it."*

So the block keeps doing the one job it exists for — raising PRs when an advisory lands against that lockfile — and stops generating version churn for an app nothing runs.

## Risks

Low, and one-directional: this only removes PRs we do not want. Security coverage of the dummy lockfile is unchanged, and the lockfile is already at patched floors for every open advisory as of #57.

The tradeoff worth naming: the dummy lockfile will now drift from current on non-security versions. That is acceptable precisely because nothing runs it — and if it ever does become load-bearing, this line should come back out.

## Verification

Config parses; 4 blocks, each retaining both a version group and a security group:

```
bundler          /gem               ver=True sec=True limit=-
bundler          /gem/spec/dummy    ver=True sec=True limit=0
npm              /site              ver=True sec=True limit=-
github-actions   /                  ver=True sec=True limit=-
```

Part of FIZZY-3597.