### PR TITLE
fix(async): FIZZY-3531: publish every service's job class regardless of load order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## [1.0.2] - 2026-09-04
+
+Two bugs in the generated per-service job classes. Both are silent, and both
+surface somewhere other than where they were caused.
+
+### Fixed
+
+- **Services loaded before ActiveJob never published a job class.** The
+  `inherited` hook that creates `Foo::ServiceJob` lives in the async extension,
+  which is installed from `on_load(:active_job)`. Servus's own railtie
+  force-loads `app/events/*_event.rb` in `to_prepare`, and every service named
+  by an `enqueue` there loads with it — typically before anything has touched
+  `ActiveJob::Base`. Those services got no job constant at all.
+
+  A web process did not notice: `call_async` builds the class lazily on first
+  use. A worker did — it resolves a job by its serialized name and never calls
+  `call_async` — so every event-invoked async service failed deserialization
+  with `ActiveJob::UnknownJobClassError`, and only once the event actually
+  fired.
+
+  Installing the extension now backfills job classes for services that are
+  already defined, so every process has them after boot regardless of load
+  order.
+
+- **The generated job class overwrote an application class of the same name.**
+  The `const_set` publishing `FooJob` was unconditional, so an app with a
+  service `Foo` and its own `FooJob` had its job silently replaced. The
+  constant survived and answered to `perform_later`, but lost its own constants
+  and class methods — so the symptom was an `uninitialized constant
+  FooJob::SOME_SETTING` in code with no apparent connection to Servus, and
+  under production eager-load a `FooJob.perform_later` that ran the wrong thing
+  entirely.
+
+  A name the application already owns is now left alone, and the skip is logged
+  naming both the service and the constant. The service keeps working; only its
+  job goes unnamed, which means `call_async` on that one service is
+  unavailable until the service or the job is renamed. A pending Zeitwerk
+  autoload counts as the application's without being resolved, and a constant
+  holding a job Servus generated earlier is still reclaimed, so development
+  reloads are unaffected.
+
 ## [1.0.1] - 2026-08-28
 
 Servus now accepts `json-schema` 6 as well as 5. The dependency was `~> 5`;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,15 @@ surface somewhere other than where they were caused.
   entirely.
 
   A name the application already owns is now left alone, and the skip is logged
-  naming both the service and the constant. The service keeps working; only its
-  job goes unnamed, which means `call_async` on that one service is
-  unavailable until the service or the job is renamed. A pending Zeitwerk
-  autoload counts as the application's without being resolved, and a constant
-  holding a job Servus generated earlier is still reclaimed, so development
-  reloads are unaffected.
+  naming both the service and the constant. The service keeps working
+  synchronously; only its job goes unnamed, and because ActiveJob serializes
+  jobs by class name, `call_async` on that one service now raises
+  `Errors::JobNameConflictError` at the call site — enqueueing the unnamed job
+  would succeed and then fail on the worker at deserialization, far from the
+  cause. Event `enqueue` invocations go through `call_async` and raise the same
+  error. A pending Zeitwerk autoload counts as the application's without being
+  resolved, and a constant holding a job Servus generated earlier is still
+  reclaimed, so development reloads are unaffected.
 
 ## [1.0.1] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [1.0.2] - 2026-09-04
+## [1.0.2] - 2026-09-07
 
 Two bugs in the generated per-service job classes. Both are silent, and both
 surface somewhere other than where they were caused.

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    servus (1.0.1)
+    servus (1.0.2)
       activesupport (>= 8.0)
       json-schema (>= 5, < 7)
 

--- a/gem/lib/servus/extensions/async/call.rb
+++ b/gem/lib/servus/extensions/async/call.rb
@@ -166,6 +166,12 @@ module Servus
         # {#inherited}) means Rails' production eager-load defines every service's job
         # at boot, so worker processes can constantize the serialized job name.
         #
+        # An app that already owns that constant keeps it: +Foo+ alongside a
+        # hand-written +FooJob+ is ordinary Rails, and overwriting it replaced a real
+        # job class with this one silently. The generated class is still returned so
+        # the service keeps working, but it is unnamed and therefore not enqueueable —
+        # hence the warning.
+        #
         # @return [Class<Servus::Extensions::Async::Job>] the generated job class
         # @api private
         def build_servus_job_class
@@ -174,9 +180,56 @@ module Servus
           klass = Class.new(Servus::Extensions::Async::Job)
           klass.servus_service = self
 
-          module_parent.const_set("#{name.demodulize}Job", klass)
+          publish_job_const("#{name.demodulize}Job", klass)
 
           klass
+        end
+
+        # Installs the generated job as a sibling constant, unless the application
+        # owns that name — in which case its class is left alone and the skip is
+        # logged.
+        #
+        # @param const_name [String]
+        # @param klass [Class<Servus::Extensions::Async::Job>]
+        # @return [void]
+        # @api private
+        def publish_job_const(const_name, klass)
+          unless job_const_available?(const_name)
+            return Servus::Support::Logger.log_job_class_conflict(self, qualified_const_name(const_name))
+          end
+
+          # Reclaiming a stale generated job: drop it first so Ruby does not warn
+          # about an already-initialized constant on every reload.
+          module_parent.send(:remove_const, const_name) if module_parent.const_defined?(const_name, false)
+          module_parent.const_set(const_name, klass)
+        end
+
+        # Whether this service may publish its job class as +const_name+.
+        #
+        # Free names are available, and so is a name already holding a generated job —
+        # that is our own constant from a previous definition, which survives a
+        # development reload when the parent namespace is +Object+ and therefore
+        # unmanaged by Zeitwerk.
+        #
+        # A pending autoload is treated as the app's without resolving it: forcing the
+        # load here would run app code in the middle of defining a service.
+        #
+        # @param const_name [String]
+        # @return [Boolean]
+        # @api private
+        def job_const_available?(const_name)
+          return true unless module_parent.const_defined?(const_name, false)
+          return false if module_parent.autoload?(const_name)
+
+          existing = module_parent.const_get(const_name, false)
+          existing.is_a?(Class) && existing <= Servus::Extensions::Async::Job
+        end
+
+        # @param const_name [String]
+        # @return [String] the constant's fully qualified name
+        # @api private
+        def qualified_const_name(const_name)
+          module_parent.equal?(Object) ? const_name : "#{module_parent.name}::#{const_name}"
         end
       end
     end

--- a/gem/lib/servus/extensions/async/call.rb
+++ b/gem/lib/servus/extensions/async/call.rb
@@ -70,21 +70,18 @@ module Servus
         # @see Servus::Base.call
         # @see #servus_job_class
         def call_async(**args)
-          # Extract ActiveJob configuration options
-          job_options = args.slice(:wait, :wait_until, :queue, :priority)
-          job_options.merge!(args.delete(:job_options) || {}) # merge custom job options
-          job_options.compact!
+          refuse_nameless_job!
 
-          # Remove special keys that shouldn't be passed to the service
-          args.except!(:wait, :wait_until, :queue, :priority, :job_options)
+          job_options = extract_job_options!(args)
 
           # The named job class identifies the service — only args are serialized.
           job = job_options.any? ? servus_job_class.set(**job_options) : servus_job_class
           job.perform_later(**args)
-        rescue Servus::Support::Errors::ServiceError, Servus::Events::Errors::Error
+        rescue Servus::Support::Errors::ServiceError, Servus::Events::Errors::Error, Errors::AsyncError
           # With the :inline and :test adapters perform_later runs the service,
-          # so Servus's own errors surface here. Wrapping them as an enqueue
-          # failure would blame the wrong layer.
+          # so Servus's own errors surface here — as do this extension's own,
+          # like the name-conflict refusal above. Wrapping any of them as an
+          # enqueue failure would blame the wrong layer.
           raise
         rescue StandardError => e
           raise Errors::JobEnqueueError, "Failed to enqueue async job for #{self}: #{e.message}"
@@ -158,6 +155,23 @@ module Servus
 
         private
 
+        # Splits ActiveJob configuration out of the combined argument hash, mutating
+        # +args+ so only the service's own arguments remain.
+        #
+        # @param args [Hash] combined service arguments and job configuration options
+        # @return [Hash] the ActiveJob options (+wait+, +queue+, …) for +set+
+        # @api private
+        def extract_job_options!(args)
+          job_options = args.slice(:wait, :wait_until, :queue, :priority)
+          job_options.merge!(args.delete(:job_options) || {}) # merge custom job options
+          job_options.compact!
+
+          # Remove special keys that shouldn't be passed to the service
+          args.except!(:wait, :wait_until, :queue, :priority, :job_options)
+
+          job_options
+        end
+
         # Generates a named job subclass for this service and installs it as a sibling
         # constant in the service's parent namespace.
         #
@@ -169,8 +183,8 @@ module Servus
         # An app that already owns that constant keeps it: +Foo+ alongside a
         # hand-written +FooJob+ is ordinary Rails, and overwriting it replaced a real
         # job class with this one silently. The generated class is still returned so
-        # the service keeps working, but it is unnamed and therefore not enqueueable —
-        # hence the warning.
+        # the service keeps working, but it is unnamed — {#call_async} refuses it with
+        # {Errors::JobNameConflictError} rather than enqueue an unresolvable job.
         #
         # @return [Class<Servus::Extensions::Async::Job>] the generated job class
         # @api private
@@ -180,9 +194,29 @@ module Servus
           klass = Class.new(Servus::Extensions::Async::Job)
           klass.servus_service = self
 
-          publish_job_const("#{name.demodulize}Job", klass)
+          publish_job_const(servus_job_const_name, klass)
 
           klass
+        end
+
+        # @return [String] the sibling constant the service's job is published under
+        # @api private
+        def servus_job_const_name
+          "#{name.demodulize}Job"
+        end
+
+        # A job with no name lost its constant to the application (see
+        # {#publish_job_const}). ActiveJob serializes a job by its class name, so
+        # enqueueing it would succeed and then fail on the worker at
+        # deserialization — refuse at the call site instead.
+        #
+        # @raise [Errors::JobNameConflictError] when the service's job is unnamed
+        # @return [void]
+        # @api private
+        def refuse_nameless_job!
+          return unless servus_job_class.name.nil?
+
+          raise Errors::JobNameConflictError.for(self, qualified_const_name(servus_job_const_name))
         end
 
         # Installs the generated job as a sibling constant, unless the application

--- a/gem/lib/servus/extensions/async/errors.rb
+++ b/gem/lib/servus/extensions/async/errors.rb
@@ -22,6 +22,29 @@ module Servus
         #   Services::SendEmail::Service.call_async(user_id: 123)
         #   # => Servus::Extensions::Async::Errors::JobEnqueueError: Failed to enqueue async job
         class JobEnqueueError < AsyncError; end
+
+        # Raised when +call_async+ is invoked on a service whose generated job was
+        # never published because the application already owns the constant.
+        #
+        # The generated job class exists but has no name, and ActiveJob serializes a
+        # job by its class name — enqueueing it would succeed and then fail on the
+        # worker at deserialization, far from the call site. Refusing here keeps the
+        # failure where it was caused.
+        #
+        # @see Servus::Extensions::Async::Call#call_async
+        class JobNameConflictError < AsyncError
+          # @param service [Class] the service whose job constant is taken
+          # @param const_name [String] the constant the application owns
+          # @return [JobNameConflictError]
+          def self.for(service, const_name)
+            new(
+              "Cannot enqueue #{service.name}: its generated job was not published because " \
+              "#{const_name} is already defined by the application. An unnamed job would " \
+              'enqueue but no worker could deserialize it. Rename the service or the ' \
+              "application's #{const_name} to stop the collision."
+            )
+          end
+        end
       end
     end
   end

--- a/gem/lib/servus/extensions/async/ext.rb
+++ b/gem/lib/servus/extensions/async/ext.rb
@@ -12,6 +12,7 @@ module Servus
     module Async
       require 'active_support/core_ext/module/introspection' # Module#module_parent
       require 'active_support/core_ext/string/inflections' # String#demodulize
+      require 'active_support/core_ext/class/subclasses' # Class#descendants
 
       require 'servus/extensions/async/errors'
       require 'servus/extensions/async/job'
@@ -21,6 +22,33 @@ module Servus
       #
       # @api private
       module Ext; end
+
+      # Installs async support on {Servus::Base} and backfills job classes for
+      # services that were already defined.
+      #
+      # The backfill exists because {Call#inherited} — which publishes a service's
+      # job constant — only exists once this module is installed, and installation
+      # is deferred to +on_load(:active_job)+. Servus's own railtie force-loads
+      # +app/events/*_event.rb+, and every service named by an +enqueue+ there loads
+      # with it, typically before anything has touched +ActiveJob::Base+. Those
+      # services would otherwise never publish a job constant, and a worker — which
+      # resolves jobs by name and never calls {Call#call_async} — would fail
+      # deserialization with +ActiveJob::UnknownJobClassError+.
+      #
+      # Only services still reachable under their own name are backfilled. An
+      # anonymous service has no constant to publish, and a class whose name no
+      # longer resolves to it — replaced by a reload, or defined under a namespace
+      # that has since gone — has nothing to publish it under either.
+      #
+      # @return [void]
+      # @api private
+      def self.install!
+        Servus::Base.extend(Call)
+
+        Servus::Base.descendants.each do |service|
+          service.servus_job_class if service.name&.safe_constantize.equal?(service)
+        end
+      end
     end
   end
 end

--- a/gem/lib/servus/railtie.rb
+++ b/gem/lib/servus/railtie.rb
@@ -14,7 +14,7 @@ module Servus
     initializer 'servus.job_async' do
       ActiveSupport.on_load(:active_job) do
         require 'servus/extensions/async/ext'
-        Servus::Base.extend Servus::Extensions::Async::Call
+        Servus::Extensions::Async.install!
       end
     end
 

--- a/gem/lib/servus/support/logger.rb
+++ b/gem/lib/servus/support/logger.rb
@@ -104,6 +104,22 @@ module Servus
         logger.warn("Schema fragment #{key.inspect} was already registered with a different value; replacing it.")
       end
 
+      # Logs that a service could not publish its generated job class because the
+      # constant is already taken by the application.
+      #
+      # The application's class is left alone. The service still runs, but its
+      # generated job has no name, so +call_async+ on it cannot be serialized.
+      #
+      # @param service_class [Class<Servus::Base>] The service whose job was not published
+      # @param const_name [String] The constant the application already owns
+      def self.log_job_class_conflict(service_class, const_name)
+        logger.warn(
+          "#{service_class.name} did not publish its generated job as #{const_name} — that constant " \
+          'is already defined by the application. The application class is unchanged; ' \
+          "#{service_class.name}.call_async cannot be enqueued until the service or the job is renamed."
+        )
+      end
+
       # Filters parameters for logging based on the configured filter list.
       #
       # @param params [Hash] The parameters to filter

--- a/gem/lib/servus/version.rb
+++ b/gem/lib/servus/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Servus
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/gem/spec/servus/extensions/async/call_spec.rb
+++ b/gem/spec/servus/extensions/async/call_spec.rb
@@ -114,6 +114,111 @@ RSpec.describe '.call_async extension', type: :job do
     end.to raise_error(Servus::Events::Errors::AnonymousServiceError)
   end
 
+  describe 'a job constant the application already owns' do
+    # Foo alongside a hand-written FooJob is ordinary Rails. Overwriting it left the
+    # app's job reachable by name but stripped of its own constants and methods, and
+    # said nothing.
+    it 'leaves the application class in place and warns' do
+      stub_const('OwnedJobNamespace', Module.new)
+      app_job = Class.new(ActiveJob::Base)
+      OwnedJobNamespace.const_set(:ServiceJob, app_job)
+
+      allow(Servus::Support::Logger).to receive(:log_job_class_conflict)
+
+      OwnedJobNamespace.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+
+      expect(OwnedJobNamespace::ServiceJob).to equal(app_job)
+      expect(Servus::Support::Logger)
+        .to have_received(:log_job_class_conflict)
+        .with(OwnedJobNamespace::Service, 'OwnedJobNamespace::ServiceJob')
+    end
+
+    it 'still builds a job class so the service keeps working' do
+      stub_const('OwnedJobNamespace2', Module.new)
+      OwnedJobNamespace2.const_set(:ServiceJob, Class.new(ActiveJob::Base))
+
+      allow(Servus::Support::Logger).to receive(:log_job_class_conflict)
+
+      OwnedJobNamespace2.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+
+      job = OwnedJobNamespace2::Service.servus_job_class
+
+      expect(job.servus_service).to eq(OwnedJobNamespace2::Service)
+      expect(job.name).to be_nil
+    end
+
+    # A pending Zeitwerk autoload is the app's constant. Resolving it to find out
+    # would run app code in the middle of defining a service.
+    it 'does not resolve a pending autoload to decide' do
+      stub_const('AutoloadNamespace', Module.new)
+      AutoloadNamespace.autoload(:ServiceJob, '/nonexistent/service_job.rb')
+
+      allow(Servus::Support::Logger).to receive(:log_job_class_conflict)
+
+      expect do
+        AutoloadNamespace.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+      end.not_to raise_error
+
+      expect(AutoloadNamespace.autoload?(:ServiceJob)).to eq('/nonexistent/service_job.rb')
+    end
+
+    # A generated job left on an unmanaged namespace survives a development reload,
+    # so the redefined service has to be able to reclaim its own constant.
+    it 'reclaims a constant holding a previously generated job' do
+      stub_const('ReloadNamespace', Module.new)
+      ReloadNamespace.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+      first = ReloadNamespace::ServiceJob
+
+      # A reload replaces the service class; the generated job constant is not
+      # Zeitwerk-managed and is still sitting there when the new one is defined.
+      ReloadNamespace.send(:remove_const, :Service)
+      ReloadNamespace.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+
+      expect(ReloadNamespace::ServiceJob).not_to equal(first)
+      expect(ReloadNamespace::ServiceJob.servus_service).to eq(ReloadNamespace::Service)
+    end
+  end
+
+  describe '.install!' do
+    # Servus's railtie force-loads app/events/*_event.rb, and every service named by
+    # an `enqueue` there loads with it — before anything touches ActiveJob::Base and
+    # therefore before `inherited` exists to publish job constants. A worker resolves
+    # jobs by name and never calls call_async, so it failed deserialization.
+    it 'backfills job classes for services defined before the extension installed' do
+      stub_const('PreloadNamespace', Module.new)
+      PreloadNamespace.module_eval('class Service < Servus::Base; end', __FILE__, __LINE__)
+
+      # The state a service reaches when it loads before ActiveJob: the class exists,
+      # `inherited` never published its job, and nothing has asked for one since.
+      PreloadNamespace.send(:remove_const, :ServiceJob)
+      PreloadNamespace::Service.remove_instance_variable(:@servus_job_class)
+
+      expect { 'PreloadNamespace::ServiceJob'.constantize }.to raise_error(NameError)
+
+      Servus::Extensions::Async.install!
+
+      expect(PreloadNamespace.const_defined?(:ServiceJob, false)).to be(true)
+      expect(PreloadNamespace::ServiceJob.servus_service).to eq(PreloadNamespace::Service)
+    end
+
+    it 'skips services with no constant to publish under' do
+      anonymous = Class.new(Servus::Base)
+
+      # A service whose namespace has gone — the state a stubbed or reloaded
+      # constant leaves behind. Resolving its parent would raise.
+      # Set and removed directly rather than with stub_const, whose teardown would
+      # trip over the constant already being gone.
+      Object.const_set(:DepartedNamespace, Module.new)
+      DepartedNamespace.module_eval('class Service < Servus::Base; end', __FILE__, __LINE__)
+      departed = DepartedNamespace::Service
+      Object.send(:remove_const, :DepartedNamespace)
+
+      expect { Servus::Extensions::Async.install! }.not_to raise_error
+      expect(anonymous.instance_variable_get(:@servus_job_class)).to be_nil
+      expect(departed.name).to eq('DepartedNamespace::Service')
+    end
+  end
+
   describe 'anonymous services' do
     # ActiveJob resolves a job on the worker by its serialized class name, so
     # there is nothing to serialize for a class with no name.

--- a/gem/spec/servus/extensions/async/call_spec.rb
+++ b/gem/spec/servus/extensions/async/call_spec.rb
@@ -147,6 +147,25 @@ RSpec.describe '.call_async extension', type: :job do
       expect(job.name).to be_nil
     end
 
+    # ActiveJob serializes a job by its class name, and the conflicted service's
+    # job has none. Without this guard, perform_later happily enqueues a payload
+    # with `job_class: nil` — the failure only surfaces on the worker, far from
+    # the call site, which is the same pathology as the bugs this release fixes.
+    it 'refuses call_async instead of enqueueing a job no worker could resolve' do
+      stub_const('ConflictedCallNamespace', Module.new)
+      ConflictedCallNamespace.const_set(:ServiceJob, Class.new(ActiveJob::Base))
+
+      allow(Servus::Support::Logger).to receive(:log_job_class_conflict)
+
+      ConflictedCallNamespace.module_eval('class Service < AsyncFixtureService; end', __FILE__, __LINE__)
+
+      expect { ConflictedCallNamespace::Service.call_async(test: 'data') }
+        .to raise_error(Servus::Extensions::Async::Errors::JobNameConflictError,
+                        /ConflictedCallNamespace::ServiceJob/)
+
+      expect(ActiveJob::Base.queue_adapter.enqueued_jobs).to be_empty
+    end
+
     # A pending Zeitwerk autoload is the app's constant. Resolving it to find out
     # would run app code in the middle of defining a service.
     it 'does not resolve a pending autoload to decide' do

--- a/gem/spec/spec_support/active_job_loader.rb
+++ b/gem/spec/spec_support/active_job_loader.rb
@@ -8,4 +8,4 @@ require 'active_job/base'
 # without this the whole suite runs with `call_async` undefined — which since
 # 1.0.0 means no event invocation works at all.
 require 'servus/extensions/async/ext'
-Servus::Base.extend(Servus::Extensions::Async::Call)
+Servus::Extensions::Async.install!

--- a/site/features/async-execution.md
+++ b/site/features/async-execution.md
@@ -83,6 +83,12 @@ Servus generates a dedicated ActiveJob class for each service, named after it. F
 
 You never write or reference these classes yourself — they're created for you when the service is defined.
 
+### When the name is already taken
+
+`Foo` alongside a hand-written `FooJob` is ordinary Rails, so Servus does not overwrite a job constant the application already owns. Your class stays exactly as you wrote it, and Servus logs a warning naming the service and the constant it skipped.
+
+The service still works — it just has no *named* job, so `call_async` on it has nothing ActiveJob can serialize. If you want that service in the background, rename either the service or your job so the two stop colliding.
+
 ## Per-service job configuration
 
 Use the `async` class method to configure a service's job — queue, priority, retries, and anything else ActiveJob supports:
@@ -128,7 +134,7 @@ Treasury::TransferGold::Service.call_async(**args)
 ```
 
 ::: warning Workers must eager-load
-Because a job is serialized by its class name, the worker process has to be able to resolve that name. Servus defines each service's job when the service class loads, so under Rails' production eager-loading (the default) every job exists at boot. If you run workers with eager-loading off, make sure the service gets referenced before its jobs run.
+Because a job is serialized by its class name, the worker process has to be able to resolve that name. Servus defines each service's job when the service class loads, and backfills any service that loaded before ActiveJob did, so under Rails' production eager-loading (the default) every job exists at boot. If you run workers with eager-loading off, make sure the service gets referenced before its jobs run.
 :::
 
 ## Error behavior

--- a/site/features/async-execution.md
+++ b/site/features/async-execution.md
@@ -87,7 +87,7 @@ You never write or reference these classes yourself — they're created for you 
 
 `Foo` alongside a hand-written `FooJob` is ordinary Rails, so Servus does not overwrite a job constant the application already owns. Your class stays exactly as you wrote it, and Servus logs a warning naming the service and the constant it skipped.
 
-The service still works — it just has no *named* job, so `call_async` on it has nothing ActiveJob can serialize. If you want that service in the background, rename either the service or your job so the two stop colliding.
+The service still works synchronously — it just has no *named* job, and ActiveJob serializes jobs by class name. Calling `call_async` on it (directly or through an event `enqueue`) raises `Servus::Extensions::Async::Errors::JobNameConflictError` at the call site, rather than enqueueing a job no worker could ever resolve. If you want that service in the background, rename either the service or your job so the two stop colliding.
 
 ## Per-service job configuration
 


### PR DESCRIPTION
## What

Two bugs in the generated per-service job classes. Both fail silently, and both surface somewhere other than where they were caused. Fixes **FIZZY-3531** and **FIZZY-3483**; released as **1.0.2**.

## Bug 1 — services loaded before ActiveJob never got a job class (FIZZY-3531)

`Foo::ServiceJob` is published by an `inherited` hook that lives in the async extension, and that extension is installed from `on_load(:active_job)`. But Servus's own railtie force-loads `app/events/*_event.rb` in `to_prepare`, and every service named by an `enqueue` there loads with it — typically before anything has touched `ActiveJob::Base`. Those services got no job constant at all.

Web processes never noticed: `call_async` builds the class lazily on first use. Workers did — they resolve a job by its serialized name and never call `call_async` — so every event-invoked async service failed deserialization with `ActiveJob::UnknownJobClassError`, and only once the event actually fired.

**Fix:** extracted `Servus::Extensions::Async.install!`, called from the railtie in place of the bare `extend`. It extends `Call` as before, then backfills `servus_job_class` for services already defined.

The backfill only touches services still reachable under their own name (`service.name&.safe_constantize.equal?(service)`). That guard is not defensive padding — iterating every descendant crashed with `NameError` on a class whose namespace had gone, which at `install!` time would be a hard boot failure. It also subsumes the anonymous-service case.

## Bug 2 — the generated class overwrote an app class of the same name (FIZZY-3483)

The `const_set` was unconditional, so an app with a service `Foo` and its own `FooJob` had its job silently replaced. The constant survived and answered to `perform_later`, but lost its own constants and class methods — so the symptom was `uninitialized constant FooJob::SOME_SETTING` in code with no visible connection to Servus, and under production eager-load a `FooJob.perform_later` that ran the wrong thing entirely. Nexus hit this three times (zarpay/nexus#581) and currently carries the guard as a local monkey-patch it can now drop.

**Fix:** a name the app already owns is left alone, and the skip is logged naming both the service and the constant. The service keeps working; only its job goes unnamed, so `call_async` on that one service is unavailable until the service or the job is renamed.

Two cases beyond the original proposal, both of which broke in testing:

- **A pending Zeitwerk autoload counts as the app's without being resolved.** Forcing that load mid-service-definition is a circular-load hazard.
- **A constant holding a job Servus generated earlier is still reclaimed** (with a `remove_const` first, so Ruby doesn't warn). Without this, a top-level service breaks on every dev reload — its generated `FooJob` sits on `Object`, where Zeitwerk never unloads it.

## Validation

**Gem:** 915 examples, 0 failures. Rubocop clean.

**machina/console — reproduced Bug 1 end to end** (FIZZY-3530). 32 services, 1 event-invoked:

| | services | missing job constants |
|---|---|---|
| backfill disabled, after full eager load | 32 | **1** — `Webhooks::FanOut::Service` |
| backfill enabled | 32 | **0** |

Exactly one service missing, and it's precisely the event-invoked one — matching the two `UnknownJobClassError` failures in console's production Mission Control. The trace also pinned the trigger more precisely than the ticket did: `on_load(:active_job)` fires when `app/jobs/application_job.rb` loads *during* eager load, well after `to_prepare` loaded the events, which is why eager-loading didn't save it. 992 console examples pass against 1.0.2.

**nexus — proved Bug 2's fix** (FIZZY-3483). Removed its local `const_set` monkey-patch and ran the card's own acceptance criteria against the upstream fix alone:

| Check | Result |
|---|---|
| `DistillTranscriptJob` is the app's (`MAX_DISTILL_CHARS_PER_RUN` intact) | ✅ `< ApplicationJob` |
| `SynthesizePersonBioJob` is the app's (`regenerate_debounce_key` intact) | ✅ `< ApplicationJob` |
| `SnapshotContributorRanksJob` is the app's | ✅ `< ApplicationJob` |
| Non-colliding `HumanizeBrief` still gets its published job | ✅ `HumanizeBriefJob → HumanizeBrief` |

Confirmed it genuinely took the conflict path rather than the collisions silently disappearing: `DistillTranscript.servus_job_class` exists but is `name = nil`, and the log carried exactly three conflict warnings — the three known collisions, correctly named, no false positives. **4915 examples, 0 failures.**

**zar/core — checked for regressions.** Probed unchanged on 0.6.0: 511 services, 0 missing. Not exposed, because ActionMailer pulls in `active_job/base` during boot initializers, ahead of `to_prepare`. That immunity is incidental — console declares an identical framework list and lands the other way, so core's 78 async event invocations are safe by coincidence rather than by design. Bug 2 is a verified no-op there: all its services are `<Namespace>::Service` and it has no `ServiceJob` constant anywhere.

## Consumer impact

- **machina/console** — on 0.7.0, actively broken. Bump + 6-line migration ready on `chore/fizzy-3530-servus-1x`, blocked on this release for the lockfile.
- **nexus** — FIZZY-3484 can bump straight to 1.0.2 with **no migration** (zero events, `call!`, or schema-tier usage) and delete the local monkey-patch in the same change. Verified green against its full suite.
- **zar/core** — unaffected either way; stays on 0.6.0. Its own 0.6→1.x bump is a separate project, sized at 90 `invoke` sites across 40 event files plus 34 `call!` sites.

## Risk

Bug 1's fix is additive. Bug 2's fix changes behaviour only where Servus was already destroying an app class — where the previous behaviour had no legitimate use. Apps relying on `call_async` for a colliding service lose it, which is why the skip is logged rather than silent.
